### PR TITLE
HostデバイスプラグインがSearchDeviceで見つからなくなった場合の対処

### DIFF
--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/RestartingDialogFragment.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/RestartingDialogFragment.java
@@ -70,6 +70,8 @@ public class RestartingDialogFragment extends DialogFragment {
             @Override
             protected Void doInBackground(final Void... params) {
                 DConnectApplication app = (DConnectApplication) activity.getApplication();
+                app.updateDevicePluginList();
+
                 DevicePluginManager mgr = app.getDevicePluginManager();
                 List<DevicePlugin> plugins = mgr.getDevicePlugins();
                 for (DevicePlugin plugin : plugins) {


### PR DESCRIPTION
# 修正内容
* Managerの設定画面より、全デバイスプラグインを再起動を押すことによってHostが見つかるようにした。