### PR TITLE
ThetaのWiFi検索で、トーストを表示しないように修正

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceTheta/app/src/main/java/org/deviceconnect/android/deviceplugin/theta/fragment/ConfirmationFragment.java
+++ b/dConnectDevicePlugin/dConnectDeviceTheta/app/src/main/java/org/deviceconnect/android/deviceplugin/theta/fragment/ConfirmationFragment.java
@@ -29,7 +29,6 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import org.deviceconnect.android.activity.PermissionUtility;
 import org.deviceconnect.android.deviceplugin.theta.R;
@@ -259,10 +258,10 @@ public class ConfirmationFragment extends SettingsFragment implements ThetaDevic
 
                             @Override
                             public void onFail(@NonNull String deniedPermission) {
-                                Toast.makeText(getContext(), "WiFi scan aborted.", Toast.LENGTH_LONG).show();
+                                ThetaDialogFragment.showAlert(getActivity(), getString(R.string.theta_confirm_wifi),
+                                        getString(R.string.theta_error_request_permission), null);
                             }
                         });
-                Toast.makeText(getContext(), "WiFi scan requires Location permission.", Toast.LENGTH_LONG).show();
             }
         }
     }

--- a/dConnectDevicePlugin/dConnectDeviceTheta/app/src/main/res/values-ja/strings.xml
+++ b/dConnectDevicePlugin/dConnectDeviceTheta/app/src/main/res/values-ja/strings.xml
@@ -79,4 +79,5 @@
     <string name="theta_error_usb_live_streaming">ライブストリーミング中は撮影できません。</string>
     <string name="theta_error_wrong_password">接続がタイムアウトしました。入力されたパスワードが不正でないかをご確認ください。</string>
     <string name="theta_error_import">THETAデータの取り込みに失敗しました。</string>
+    <string name="theta_error_request_permission">パーミッションの許可が取得できませんでした。</string>
 </resources>

--- a/dConnectDevicePlugin/dConnectDeviceTheta/app/src/main/res/values/strings.xml
+++ b/dConnectDevicePlugin/dConnectDeviceTheta/app/src/main/res/values/strings.xml
@@ -79,4 +79,5 @@
     <string name="theta_error_usb_live_streaming">Cannot shoot during live streaming.</string>
     <string name="theta_error_wrong_password">Connection timed out. Please confirm the entered password.</string>
     <string name="theta_error_import">Failed to import the THETA data.</string>
+    <string name="theta_error_request_permission">Failed to get a permission</string>
 </resources>


### PR DESCRIPTION
# 修正内容
* 下記問題の修正
  * Android6.0以降で、Thetaプラグインの設定画面でSony Cameraの検索を行うと位置情報の許可を求めるダイアログが表示されます。その後、「画面オーバーレイを検出」ダイアログが表示されます。
画面オーバーレイの許可が取れずに「WiFi scan abort」と表示されスキャンができません。