### PR TITLE
SonyCameraデバイスプラグインでトーストを削除して、ダイアログに変更

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceSonyCamera/app/src/main/java/org/deviceconnect/android/deviceplugin/sonycamera/activity/SonyCameraConnectingFragment.java
+++ b/dConnectDevicePlugin/dConnectDeviceSonyCamera/app/src/main/java/org/deviceconnect/android/deviceplugin/sonycamera/activity/SonyCameraConnectingFragment.java
@@ -34,7 +34,6 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import org.deviceconnect.android.activity.IntentHandlerActivity;
 import org.deviceconnect.android.activity.PermissionUtility;
@@ -186,11 +185,10 @@ public class SonyCameraConnectingFragment extends SonyCameraBaseFragment {
                             if (manager.isProviderEnabled( LocationManager.GPS_PROVIDER )) {
                                 permissionCheck();
                             } else {
-                                Toast.makeText(getContext(), "WiFi scan aborted.", Toast.LENGTH_LONG).show();
+                                showErrorDialog(getString(R.string.sonycamera_request_permission_error));
                             }
                         }
                     });
-            Toast.makeText(getContext(), "WiFi scan requires Location Service.", Toast.LENGTH_LONG).show();
         } else {
             permissionCheck();
         }
@@ -216,10 +214,9 @@ public class SonyCameraConnectingFragment extends SonyCameraBaseFragment {
 
                             @Override
                             public void onFail(@NonNull String deniedPermission) {
-                                Toast.makeText(getContext(), "WiFi scan aborted.", Toast.LENGTH_LONG).show();
+                                showErrorDialog(getString(R.string.sonycamera_request_permission_error));
                             }
                         });
-                Toast.makeText(getContext(), "WiFi scan requires Location permission.", Toast.LENGTH_LONG).show();
             }
         }
     }
@@ -336,9 +333,18 @@ public class SonyCameraConnectingFragment extends SonyCameraBaseFragment {
      * @param message エラーメッセージ
      */
     private void showErrorDialog(final String message) {
+        showErrorDialog(getString(R.string.sonycamera_confirm_wifi), message);
+    }
+
+    /**
+     * エラーダイアログを表示する.
+     *
+     * @param message エラーメッセージ
+     */
+    private void showErrorDialog(final String title, final String message) {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setIcon(android.R.drawable.ic_dialog_alert);
-        builder.setTitle(R.string.sonycamera_confirm_wifi);
+        builder.setTitle(title);
         builder.setMessage(message);
         builder.setPositiveButton(R.string.sonycamera_ok, new DialogInterface.OnClickListener() {
             @Override
@@ -349,6 +355,7 @@ public class SonyCameraConnectingFragment extends SonyCameraBaseFragment {
         builder.show();
         mServiceIdView.setText(R.string.sonycamera_no_device);
     }
+
 
     /**
      * パスワードを入力するダイアログを表示する.

--- a/dConnectDevicePlugin/dConnectDeviceSonyCamera/app/src/main/java/org/deviceconnect/android/deviceplugin/sonycamera/utils/DConnectUtil.java
+++ b/dConnectDevicePlugin/dConnectDeviceSonyCamera/app/src/main/java/org/deviceconnect/android/deviceplugin/sonycamera/utils/DConnectUtil.java
@@ -7,9 +7,6 @@ http://opensource.org/licenses/mit-license.php
 
 package org.deviceconnect.android.deviceplugin.sonycamera.utils;
 
-import org.deviceconnect.android.deviceplugin.sonycamera.BuildConfig;
-import org.deviceconnect.profile.ServiceDiscoveryProfileConstants;
-
 /**
  * ユーティリティクラス.
  * @author NTT DOCOMO, INC.
@@ -17,28 +14,13 @@ import org.deviceconnect.profile.ServiceDiscoveryProfileConstants;
 public final class DConnectUtil {
     /** SonyCameraのWiFiのプレフィックス. */
     private static final String WIFI_PREFIX = "DIRECT-";
+
     /**
      * Camera Remote APIに対応したWiFiのSSIDのサフィックスを定義.
      */
-    public static final String[] CAMERA_SUFFIX = {"HDR-AS100", "ILCE-6000", "DSC-HC60V", "DSC-HX400", "ILCE-5000",
+    private static final String[] CAMERA_SUFFIX = {"HDR-AS100", "ILCE-6000", "DSC-HC60V", "DSC-HX400", "ILCE-5000",
             "DSC-QX10", "DSC-QX100", "HDR-AS15", "HDR-AS30", "HDR-MV1", "NEX-5R", "NEX-5T", "NEX-6", "ILCE-7R/B",
             "ILCE-7/B" };
-
-    /** dConnectManagerのURI. */
-    private static final String BASE_URI = "http://localhost:4035";
-
-    /** Service Discovery ProfileのURI. */
-    private static final String DISCOVERY_URI = BASE_URI + "/" + ServiceDiscoveryProfileConstants.PROFILE_NAME;
-
-    /**
-     * デバック用フラグ.
-     */
-    private static final boolean DEBUG = BuildConfig.DEBUG;
-
-    /**
-     * デバック用タグを定義します.
-     */
-    private static final String TAG = "SONYCAMERA";
 
     /**
      * コンストラクタ. ユーティリティクラスなのでprivateにしておく。

--- a/dConnectDevicePlugin/dConnectDeviceSonyCamera/app/src/main/res/values/strings.xml
+++ b/dConnectDevicePlugin/dConnectDeviceSonyCamera/app/src/main/res/values/strings.xml
@@ -33,5 +33,6 @@
     <string name="sonycamera_cancel" translatable="false">キャンセル</string>
     <string name="sonycamera_password_dialog" translatable="false">パスワード入力ダイアログ</string>
     <string name="sonycamera_not_connected" translatable="false">Wi-Fiがつながりません</string>
+    <string name="sonycamera_request_permission_error" translatable="false">パーミッションの許可が取れませんでした。</string>
 
 </resources>


### PR DESCRIPTION
# 修正内容
* 下記問題の修正
  * Android6.0以降の時、SonyCameraプラグインの設定画面でSony Cameraの検索を行うと位置情報の許可を求めるダイアログが表示される。その後、「画面オーバーレイを検出」ダイアログが表示さる。
画面オーバーレイの許可が取れずに「WiFi scan abort」と表示されスキャンができない。