### PR TITLE
UVCデバイスプラグインのgradleビルド時にエラーが出ていた件の修正

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceUVC/gradle.properties
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/gradle.properties
@@ -1,18 +1,4 @@
-# Project-wide Gradle settings.
-
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-
-# For more details on how to configure your build environment visit
-# http://www.gradle.org/docs/current/userguide/build_environment.html
-
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
-# Default value: -Xmx10248m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+storeFile=キーストアのファイル名
+storePassword=キーストアのパスワード
+keyAlias=エイリアス名
+keyPassword=エイリアスのパスワード


### PR DESCRIPTION
# 修正内容
* signingConfigsで設定する値が取得できていなかったので修正。