### PR TITLE
Thread化対応のSDKで、GET/PUTの応答が返らなくなる不具合に対応

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/profile/HostGeolocationProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/profile/HostGeolocationProfile.java
@@ -249,7 +249,7 @@ public class HostGeolocationProfile extends GeolocationProfile implements Locati
             public void onProviderDisabled(String provider) {
                 // NOP
             }
-        }, null);
+        }, Looper.getMainLooper());
     }
 
     /**
@@ -270,7 +270,7 @@ public class HostGeolocationProfile extends GeolocationProfile implements Locati
             criteria.setAccuracy(Criteria.ACCURACY_COARSE);
         }
 
-        mLocationManager.requestLocationUpdates(mLocationManager.getBestProvider(criteria, true), interval, 0, this);
+        mLocationManager.requestLocationUpdates(mLocationManager.getBestProvider(criteria, true), interval, 0, this, Looper.getMainLooper());
     }
 
     /**


### PR DESCRIPTION
# 確認方法
* デバイス確認画面などでGeolocationの動作確認をする。