### PR TITLE
Bugfix filtering attribute

### DIFF
--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/build.gradle
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/build.gradle
@@ -9,6 +9,7 @@ android {
         targetSdkVersion 23
         versionCode 1
         versionName '1.1.0'
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     packagingOptions {
@@ -77,6 +78,11 @@ dependencies {
     compile fileTree(include: '*.jar', dir: 'libs')
     compile project(':dconnect-sdk-for-android')
     compile 'com.android.support:support-v4:23.1.0'
+
+    testCompile 'junit:junit:4.12'
+    androidTestCompile 'org.hamcrest:hamcrest-library:1.3'
+    androidTestCompile 'com.android.support:support-annotations:24.0.0'
+    androidTestCompile 'com.android.support.test:runner:0.5'
 }
 
 configurations {

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/AndroidManifest.xml
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.deviceconnect.android">
+
+    <uses-sdk
+        android:minSdkVersion="14"
+        android:targetSdkVersion="19" />
+
+    <application>
+    </application>
+
+</manifest>

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/java/org/deviceconnect/android/profile/ServiceInformationProfileTest.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/java/org/deviceconnect/android/profile/ServiceInformationProfileTest.java
@@ -1,0 +1,124 @@
+package org.deviceconnect.android.profile;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.AndroidTestCase;
+
+import org.deviceconnect.android.profile.api.DConnectApi;
+import org.deviceconnect.android.profile.api.GetApi;
+import org.deviceconnect.android.profile.spec.DConnectApiSpec;
+import org.deviceconnect.android.profile.spec.DConnectPluginSpec;
+import org.deviceconnect.android.service.DConnectService;
+import org.deviceconnect.android.service.DConnectServiceManager;
+import org.deviceconnect.message.intent.message.IntentDConnectMessage;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.InputStream;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+
+@RunWith(AndroidJUnit4.class)
+public class ServiceInformationProfileTest extends AndroidTestCase {
+
+    @Test
+    public void testOnRequest() throws Exception {
+        final String profileName = "testProfile";
+        final String specName = profileName + ".json";
+
+        DConnectServiceManager serviceManager = new DConnectServiceManager();
+        DConnectPluginSpec pluginSpec = new DConnectPluginSpec();
+        pluginSpec.addProfileSpec(profileName.toLowerCase(), getResource(specName));
+        serviceManager.setContext(InstrumentationRegistry.getTargetContext());
+        serviceManager.setPluginSpec(pluginSpec);
+
+        // サービスを作成
+        for (int i = 0; i < 2; i++) {
+            final String serviceId = "s" + i;
+            final String attribute = "a" + i;
+            DConnectService service = new DConnectService(serviceId);
+            service.addProfile(new DConnectProfile() {
+                {
+                    addApi(new GetApi() {
+                        @Override
+                        public String getAttribute() {
+                            return attribute;
+                        }
+                        @Override
+                        public boolean onRequest(final Intent request, final Intent response) {
+                            return true;
+                        }
+                    });
+                }
+                @Override
+                public String getProfileName() {
+                    return profileName;
+                }
+            });
+            serviceManager.addService(service);
+        }
+
+        for (DConnectService service : serviceManager.getServiceList()) {
+            DConnectProfile profile = service.getProfile("serviceInformation");
+
+            Intent request = new Intent(IntentDConnectMessage.ACTION_GET);
+            request.putExtra("profile", "serviceInformation");
+            Intent response = new Intent();
+
+            boolean isSync = profile.onRequest(request, response);
+            assertThat(isSync, is(true));
+            assertThat(response.getIntExtra("result", -1), is(0));
+            Bundle supportApis = response.getBundleExtra("supportApis");
+            assertThat(supportApis, is(notNullValue()));
+            Bundle swagger = supportApis.getBundle(profileName);
+            assertThat(swagger, is(notNullValue()));
+            assertThat(swagger.getString("swagger"), is("2.0"));
+            Bundle paths = swagger.getBundle("paths");
+            assertThat(paths, is(notNullValue()));
+            for (DConnectApi api : service.getProfile(profileName).getApiList()) {
+                DConnectApiSpec apiSpec = api.getApiSpec();
+                assertThat("Definition for " + createApiTitle(api) + " is null.", apiSpec, is(notNullValue()));
+                Bundle info = null;
+                for (String path : paths.keySet()) {
+                    if (path.equalsIgnoreCase(createPath(apiSpec))) {
+                        info = paths.getBundle(path);
+                    }
+                }
+                assertThat(info, is(notNullValue()));
+            }
+        }
+    }
+
+    private String createApiTitle(final DConnectApi api) {
+        return api.getMethod().name() + " " + createPath(api);
+    }
+
+    private String createPath(final DConnectApi api) {
+        return createPath(api.getInterface(), api.getAttribute());
+    }
+
+    private String createPath(final DConnectApiSpec apiSpec) {
+        return createPath(apiSpec.getInterfaceName(), apiSpec.getAttributeName());
+    }
+
+    private String createPath(final String interfaceName, final String attrName) {
+        String path = "/";
+        if (interfaceName != null) {
+            path += interfaceName;
+            path += "/";
+        }
+        if (attrName != null) {
+            path += attrName;
+        }
+        return path;
+    }
+
+    private InputStream getResource(final String resName) {
+        return getClass().getClassLoader().getResourceAsStream(resName);
+    }
+}

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/java/org/deviceconnect/android/profile/ServiceInformationProfileTest.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/java/org/deviceconnect/android/profile/ServiceInformationProfileTest.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 
@@ -77,20 +78,44 @@ public class ServiceInformationProfileTest extends AndroidTestCase {
             assertThat(supportApis, is(notNullValue()));
             Bundle swagger = supportApis.getBundle(profileName);
             assertThat(swagger, is(notNullValue()));
-            assertThat(swagger.getString("swagger"), is("2.0"));
+            assertThat(swagger.getString("swagger"), is(notNullValue()));
+            assertThat(swagger.getString("basePath"), is(notNullValue()));
+            Bundle info = swagger.getBundle("info");
+            assertThat(info, is(notNullValue()));
+            assertThat(info.getString("title"), is(notNullValue()));
+            assertThat(info.getString("version"), is(notNullValue()));
+            assertThat(info.containsKey("description"), is(false));
+            assertThat(swagger.getStringArray("consumes"), is(notNullValue()));
             Bundle paths = swagger.getBundle("paths");
             assertThat(paths, is(notNullValue()));
             for (DConnectApi api : service.getProfile(profileName).getApiList()) {
                 DConnectApiSpec apiSpec = api.getApiSpec();
                 assertThat("Definition for " + createApiTitle(api) + " is null.", apiSpec, is(notNullValue()));
-                Bundle info = null;
+                Bundle foundPath = null;
                 for (String path : paths.keySet()) {
                     if (path.equalsIgnoreCase(createPath(apiSpec))) {
-                        info = paths.getBundle(path);
+                        foundPath = paths.getBundle(path);
                     }
                 }
-                assertThat(info, is(notNullValue()));
+                assertThat(foundPath, is(notNullValue()));
+                Bundle op = foundPath.getBundle("get");
+                assertThat(op, is(notNullValue()));
+                assertThat(op.getString("x-type"), is(notNullValue()));
+                assertThat(op.containsKey("summary"), is(false));
+                assertThat(op.containsKey("description"), is(false));
+                Bundle[] parameters = (Bundle[]) op.getParcelableArray("parameters");
+                assertThat(parameters, is(notNullValue()));
+
+                for (Bundle parameter : parameters) {
+                    assertThat(parameter.getString("name"), is(notNullValue()));
+                    assertThat(parameter.containsKey("description"), is(false));
+                    assertThat(parameter.getString("in"), is(notNullValue()));
+                    assertThat(parameter.getBoolean("required"), is(true));
+                    assertThat(parameter.getString("type"), is(notNullValue()));
+                }
+                assertThat(op.containsKey("responses"), is(false));
             }
+            assertThat(swagger.containsKey("definitions"), is(false));
         }
     }
 

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/java/org/deviceconnect/android/profile/spec/DConnectProfileSpecTest.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/java/org/deviceconnect/android/profile/spec/DConnectProfileSpecTest.java
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertThat;
 public class DConnectProfileSpecTest extends InstrumentationTestCase {
 
     @Test
-    public void toBundle() throws Exception {
+    public void testDeepCopy() throws Exception {
         Bundle src = new Bundle();
         src.putInt("int", 1);
         src.putLong("long", 1L);

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/java/org/deviceconnect/android/profile/spec/DConnectProfileSpecTest.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/java/org/deviceconnect/android/profile/spec/DConnectProfileSpecTest.java
@@ -1,0 +1,67 @@
+package org.deviceconnect.android.profile.spec;
+
+import android.os.Bundle;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.InstrumentationTestCase;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(AndroidJUnit4.class)
+public class DConnectProfileSpecTest extends InstrumentationTestCase {
+
+    @Test
+    public void toBundle() throws Exception {
+        Bundle src = new Bundle();
+        src.putInt("int", 1);
+        src.putLong("long", 1L);
+        src.putDouble("double", 1d);
+        src.putBoolean("boolean", true);
+        src.putString("string", "");
+        src.putIntArray("intArray", new int[] {1, 1, 1});
+        src.putLongArray("longArray", new long[] {1, 1, 1});
+        src.putDoubleArray("doubleArray", new double[] {1, 1, 1});
+        src.putBooleanArray("booleanArray", new boolean[] {true, true, true});
+        src.putStringArray("stringArray", new String[] {"", "", ""});
+        Bundle srcObj = new Bundle();
+        srcObj.putInt("int", 1);
+        srcObj.putLong("long", 1L);
+        srcObj.putDouble("double", 1d);
+        srcObj.putBoolean("boolean", true);
+        srcObj.putString("string", "");
+        srcObj.putIntArray("intArray", new int[] {1, 1, 1});
+        srcObj.putLongArray("longArray", new long[] {1, 1, 1});
+        srcObj.putDoubleArray("doubleArray", new double[] {1, 1, 1});
+        srcObj.putBooleanArray("booleanArray", new boolean[] {true, true, true});
+        srcObj.putStringArray("stringArray", new String[] {"", "", ""});
+        src.putBundle("object", srcObj);
+
+        Bundle dst = new Bundle();
+        DConnectProfileSpec.deepCopy(src, dst);
+
+        assertThat(dst.getInt("int"), is(1));
+        assertThat(dst.getLong("long"), is(1L));
+        assertThat(dst.getDouble("double"), is(1d));
+        assertThat(dst.getBoolean("boolean"), is(true));
+        assertThat(dst.getString("string"), is(""));
+        assertThat(dst.getIntArray("intArray"), is(new int[] {1, 1, 1}));
+        assertThat(dst.getLongArray("longArray"), is(new long[] {1, 1, 1}));
+        assertThat(dst.getDoubleArray("doubleArray"), is(new double[] {1, 1, 1}));
+        assertThat(dst.getBooleanArray("booleanArray"), is(new boolean[] {true, true, true}));
+        assertThat(dst.getStringArray("stringArray"), is(new String[] {"", "", ""}));
+        Bundle dstObj = dst.getBundle("object");
+        assertThat(dstObj.getInt("int"), is(1));
+        assertThat(dstObj.getLong("long"), is(1L));
+        assertThat(dstObj.getDouble("double"), is(1d));
+        assertThat(dstObj.getBoolean("boolean"), is(true));
+        assertThat(dstObj.getString("string"), is(""));
+        assertThat(dstObj.getIntArray("intArray"), is(new int[] {1, 1, 1}));
+        assertThat(dstObj.getLongArray("longArray"), is(new long[] {1, 1, 1}));
+        assertThat(dstObj.getDoubleArray("doubleArray"), is(new double[] {1, 1, 1}));
+        assertThat(dstObj.getBooleanArray("booleanArray"), is(new boolean[] {true, true, true}));
+        assertThat(dstObj.getStringArray("stringArray"), is(new String[] {"", "", ""}));
+    }
+}

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/resources/testProfile.json
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/resources/testProfile.json
@@ -6,15 +6,35 @@
     "version": "1.0",
     "description": ""
   },
-  "consumes": [],
+  "consumes": [
+    "application/json"
+  ],
   "paths": {
     "/a0": {
       "get": {
         "x-type": "one-shot",
-        "parameters": [],
+        "summary": "",
+        "description": "",
+        "parameters": [
+          {
+            "name": "serviceId",
+            "description": "",
+            "in": "query",
+            "required": true,
+            "type": "string"
+          }
+        ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/CommonResponse"
+            },
+            "examples": {
+              "application/json": {
+                "result": 0
+              }
+            }
           }
         }
       }
@@ -22,11 +42,38 @@
     "/a1": {
       "get": {
         "x-type": "one-shot",
-        "parameters": [],
+        "summary": "",
+        "description": "",
+        "parameters": [
+          {
+            "name": "serviceId",
+            "description": "",
+            "in": "query",
+            "required": true,
+            "type": "string"
+          }
+        ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/CommonResponse"
+            }
           }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "CommonResponse": {
+      "type": "object",
+      "required": [
+        "result"
+      ],
+      "properties": {
+        "result": {
+          "type": "integer",
+          "description": ""
         }
       }
     }

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/resources/testProfile.json
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/androidTest/resources/testProfile.json
@@ -1,0 +1,34 @@
+{
+  "swagger": "2.0",
+  "basePath": "/gotapi/testProfile",
+  "info": {
+    "title": "Test Profile",
+    "version": "1.0",
+    "description": ""
+  },
+  "consumes": [],
+  "paths": {
+    "/a0": {
+      "get": {
+        "x-type": "one-shot",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/a1": {
+      "get": {
+        "x-type": "one-shot",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/spec/DConnectProfileSpec.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/spec/DConnectProfileSpec.java
@@ -11,6 +11,7 @@ import android.os.Bundle;
 
 import org.deviceconnect.message.DConnectMessage;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -39,7 +40,8 @@ public class DConnectProfileSpec implements DConnectSpecConstants {
      * @param bundle Bundleのインスタンス
      */
     void setBundle(final Bundle bundle) {
-        mBundle = bundle;
+        mBundle = new Bundle();
+        deepCopy(bundle, mBundle);
     }
 
     /**
@@ -135,7 +137,59 @@ public class DConnectProfileSpec implements DConnectSpecConstants {
      * @return Bundleのインスタンス
      */
     public Bundle toBundle() {
-        return mBundle;
+        Bundle dst = new Bundle();
+        deepCopy(mBundle, dst);
+        return dst;
+    }
+
+    static void deepCopy(final Bundle src, final Bundle dst) {
+        for (String key : src.keySet()) {
+            Object obj = src.get(key);
+            if (obj == null) {
+                continue;
+            }
+
+            // NOTE:
+            //   本メソッドに入力される Bundle オブジェクトは JSONObject を変換して得たもの.
+            //   つまり、その Bundle オブジェクトは下記の型のみを含む.
+            //     int, long, double, boolean, String,
+            //     int[], long[], double[], boolean[], String[],
+            //     Bundle
+            //  よって、ここでは上記の型の値のみをコピーする.
+            if (obj instanceof Bundle) {
+                Bundle a = (Bundle) obj;
+                Bundle b = new Bundle();
+                deepCopy(a, b);
+                dst.putBundle(key, b);
+            } else if (obj instanceof int[]) {
+                int[] a = (int[]) obj;
+                int[] b = new int[a.length];
+                System.arraycopy(a, 0, b, 0, a.length);
+                dst.putIntArray(key, b);
+            } else if (obj instanceof long[]) {
+                long[] a = (long[]) obj;
+                long[] b = new long[a.length];
+                System.arraycopy(a, 0, b, 0, a.length);
+                dst.putLongArray(key, b);
+            } else if (obj instanceof double[]) {
+                double[] a = (double[]) obj;
+                double[] b = new double[a.length];
+                System.arraycopy(a, 0, b, 0, a.length);
+                dst.putDoubleArray(key, b);
+            } else if (obj instanceof boolean[]) {
+                boolean[] a = (boolean[]) obj;
+                boolean[] b = new boolean[a.length];
+                System.arraycopy(a, 0, b, 0, a.length);
+                dst.putBooleanArray(key, b);
+            } else if (obj instanceof String[]) {
+                String[] a = (String[]) obj;
+                String[] b = new String[a.length];
+                System.arraycopy(a, 0, b, 0, a.length);
+                dst.putStringArray(key, b);
+            } else if (obj instanceof Serializable) { // int, long, double, boolean, String のいずれか.
+                dst.putSerializable(key, (Serializable) obj);
+            }
+        }
     }
 
     /**

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/spec/parser/SwaggerJsonParser.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/profile/spec/parser/SwaggerJsonParser.java
@@ -154,6 +154,12 @@ class SwaggerJsonParser implements DConnectProfileSpecJsonParser, DConnectSpecCo
                     array[i] = jsonArray.getString(i);
                 }
                 bundle.putStringArray(name, array);
+            } else if (base == Boolean.class) {
+                boolean[] array = new boolean[length];
+                for (int i = 0; i < length; i++) {
+                    array[i] = jsonArray.getBoolean(i);
+                }
+                bundle.putBooleanArray(name, array);
             } else if (base == JSONObject.class) {
                 Bundle[] array = new Bundle[length];
                 for (int i = 0; i < length; i++) {

--- a/dConnectDevicePlugin/dConnectDeviceSlackMessageHook/slack-plugin/src/main/java/org/deviceconnect/android/deviceplugin/slackmessagehook/setting/fragment/ChannelListFragment.java
+++ b/dConnectDevicePlugin/dConnectDeviceSlackMessageHook/slack-plugin/src/main/java/org/deviceconnect/android/deviceplugin/slackmessagehook/setting/fragment/ChannelListFragment.java
@@ -11,6 +11,8 @@ import android.app.ListFragment;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -114,7 +116,7 @@ public class ChannelListFragment extends ListFragment implements ShowMenuFragmen
                         }
                     }
                 }
-            });
+            }, new Handler(Looper.getMainLooper()));
         } else {
             // OFFLineメッセージを表示
             emptyLayout.setVisibility(View.VISIBLE);

--- a/dConnectDevicePlugin/dConnectDeviceSlackMessageHook/slack-plugin/src/main/java/org/deviceconnect/android/deviceplugin/slackmessagehook/setting/fragment/ChannelListFragment.java
+++ b/dConnectDevicePlugin/dConnectDeviceSlackMessageHook/slack-plugin/src/main/java/org/deviceconnect/android/deviceplugin/slackmessagehook/setting/fragment/ChannelListFragment.java
@@ -11,8 +11,6 @@ import android.app.ListFragment;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.os.Bundle;
-import android.os.Handler;
-import android.os.Looper;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -116,7 +114,7 @@ public class ChannelListFragment extends ListFragment implements ShowMenuFragmen
                         }
                     }
                 }
-            }, new Handler(Looper.getMainLooper()));
+            });
         } else {
             // OFFLineメッセージを表示
             emptyLayout.setVisibility(View.VISIBLE);

--- a/dConnectDevicePlugin/dConnectDeviceSlackMessageHook/slack-plugin/src/main/java/org/deviceconnect/android/deviceplugin/slackmessagehook/slack/SlackManager.java
+++ b/dConnectDevicePlugin/dConnectDeviceSlackMessageHook/slack-plugin/src/main/java/org/deviceconnect/android/deviceplugin/slackmessagehook/slack/SlackManager.java
@@ -846,21 +846,12 @@ public class SlackManager {
         public String icon;
     }
 
-
     /**
      * Channel一覧とDM一覧を合成したものを取得
      * @param callback 取得コールバック
      */
     public void getAllChannelList(final FinishCallback<List<ListInfo>> callback) {
-        getAllChannelList(callback, null);
-    }
-
-    /**
-     * Channel一覧とDM一覧を合成したものを取得
-     * @param callback 取得コールバック
-     * @param handler Callbackを返すスレッド
-     */
-    public void getAllChannelList(final FinishCallback<List<ListInfo>> callback, final Handler handler) {
+        final Handler handler = new Handler();
         new Thread() {
             @Override
             public void run() {
@@ -942,27 +933,19 @@ public class SlackManager {
                     }
 
                     if (callback != null) {
-                        if (handler != null) {
-                            handler.post(new Runnable() {
-                                public void run() {
-                                    callback.onFinish(resList, null);
-                                }
-                            });
-                        } else {
-                            callback.onFinish(resList, null);
-                        }
+                        handler.post(new Runnable() {
+                            public void run() {
+                                callback.onFinish(resList, null);
+                            }
+                        });
                     }
                 } else {
                     if (callback != null) {
-                        if (handler != null) {
-                            handler.post(new Runnable() {
-                                public void run() {
-                                    callback.onFinish(null, err[0]);
-                                }
-                            });
-                        } else {
-                            callback.onFinish(null, err[0]);
-                        }
+                        handler.post(new Runnable() {
+                            public void run() {
+                                callback.onFinish(null, err[0]);
+                            }
+                        });
                     }
                 }
             }

--- a/dConnectDevicePlugin/dConnectDeviceSlackMessageHook/slack-plugin/src/main/java/org/deviceconnect/android/deviceplugin/slackmessagehook/slack/SlackManager.java
+++ b/dConnectDevicePlugin/dConnectDeviceSlackMessageHook/slack-plugin/src/main/java/org/deviceconnect/android/deviceplugin/slackmessagehook/slack/SlackManager.java
@@ -846,12 +846,21 @@ public class SlackManager {
         public String icon;
     }
 
+
     /**
      * Channel一覧とDM一覧を合成したものを取得
      * @param callback 取得コールバック
      */
     public void getAllChannelList(final FinishCallback<List<ListInfo>> callback) {
-        final Handler handler = new Handler();
+        getAllChannelList(callback, null);
+    }
+
+    /**
+     * Channel一覧とDM一覧を合成したものを取得
+     * @param callback 取得コールバック
+     * @param handler Callbackを返すスレッド
+     */
+    public void getAllChannelList(final FinishCallback<List<ListInfo>> callback, final Handler handler) {
         new Thread() {
             @Override
             public void run() {
@@ -933,19 +942,27 @@ public class SlackManager {
                     }
 
                     if (callback != null) {
-                        handler.post(new Runnable() {
-                            public void run() {
-                                callback.onFinish(resList, null);
-                            }
-                        });
+                        if (handler != null) {
+                            handler.post(new Runnable() {
+                                public void run() {
+                                    callback.onFinish(resList, null);
+                                }
+                            });
+                        } else {
+                            callback.onFinish(resList, null);
+                        }
                     }
                 } else {
                     if (callback != null) {
-                        handler.post(new Runnable() {
-                            public void run() {
-                                callback.onFinish(null, err[0]);
-                            }
-                        });
+                        if (handler != null) {
+                            handler.post(new Runnable() {
+                                public void run() {
+                                    callback.onFinish(null, err[0]);
+                                }
+                            });
+                        } else {
+                            callback.onFinish(null, err[0]);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## 不具合内容
プラグインSDK側の `DConnectProfileSpec` クラス (プロファイル仕様を保持するクラス) の内容が破壊されてしまうために、ServiceInformation API レスポンスの一部が消えてしまうケースがあった。

具体的には、`DConnectProfileSpec.toBundle()` メソッドによって、`DConnectProfileSpec.mBundle
` オブジェクトの内容が暴露されていた。

## 修正内容
- `DConnectProfileSpec.toBundle()`からは `Bundle` のディープコピーを返すように修正した。
- プラグインSDKに下記の単体テストを追加した。
  - `DConnectProfileSpecTest.testDeepCopy`
  - `ServiceInformationProfileTest.testOnRequest`

## 動作確認手順
1. 上記単体テストが成功することを確認。
2. Device Connect Manager のデバイス一覧画面を開く。
3. Host の POST /gotapi/canvas が正常に動作することを確認。
4. Host の PUT /gotapi/deviceOrientation/onDeviceOrientation が正常に動作することを確認。