### PR TITLE
Hostデバイスプラグインのスクリーンキャストの同期処理調整

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/screen/HostDeviceScreenCast.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/screen/HostDeviceScreenCast.java
@@ -348,21 +348,25 @@ public class HostDeviceScreenCast extends HostDevicePreviewServer implements Hos
                 }
             });
         } else {
-            stopScreenCast();
-
-            mHandler.postDelayed(new Runnable() {
+           mHandler.postDelayed(new Runnable() {
                 @Override
                 public void run() {
-                    takePhoto(listener, new FinishCallback() {
+                    new Thread(new Runnable() {
                         @Override
-                        public void onFinish() {
-                            mHandler.postDelayed(new Runnable() {
-                                public void run() {
-                                    startScreenCast();
+                        public void run() {
+                            takePhotoInternal(new OnPhotoEventListener() {
+                                @Override
+                                public void onTakePhoto(final String uri, final String filePath) {
+                                    listener.onTakePhoto(uri, filePath);
                                 }
-                            }, 500);
+
+                                @Override
+                                public void onFailedTakePhoto() {
+                                    listener.onFailedTakePhoto();
+                                }
+                            });
                         }
-                    });
+                    }).start();
                 }
             }, 500);
         }


### PR DESCRIPTION
# 修正内容
* ScreenCastが起動中の時は、Previewを起動したままスクリーンショットが撮影できるようにした。
* Android HostScreenが２度目以降起動しない点の修正。