### PR TITLE
UVCプラグインの解像度解析処理の不具合修正

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceUVC/.gitignore
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/.gitignore
@@ -1,4 +1,5 @@
 .gradle
+.externalNativeBuild
 /local.properties
 /.idea/workspace.xml
 /.idea/libraries

--- a/dConnectDevicePlugin/dConnectDeviceUVC/.gitignore
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/.gitignore
@@ -1,5 +1,4 @@
 .gradle
-.externalNativeBuild
 /local.properties
 /.idea/workspace.xml
 /.idea/libraries

--- a/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/profile/UVCMediaStreamRecordingProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/profile/UVCMediaStreamRecordingProfile.java
@@ -438,20 +438,25 @@ public class UVCMediaStreamRecordingProfile extends MediaStreamRecordingProfile 
         }
 
         byte[] resize(final byte[] frame) {
-            Bitmap src = BitmapFactory.decodeByteArray(frame, 0, frame.length);
-            if (src == null) {
-                mLogger.warning("MotionJPEG Frame could not be decoded to bitmap.");
-                return null;
+            byte[] resizedBytes = null;
+            try {
+                Bitmap src = BitmapFactory.decodeByteArray(frame, 0, frame.length);
+                if (src == null) {
+                    mLogger.warning("MotionJPEG Frame could not be decoded to bitmap.");
+                    return null;
+                }
+
+                int w = mWidth != null ? mWidth : src.getWidth();
+                int h = mHeight != null ? mHeight : src.getHeight();
+
+                Bitmap resizedBitmap = Bitmap.createScaledBitmap(src, w, h, true);
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                resizedBitmap.compress(Bitmap.CompressFormat.JPEG, 100, baos);
+                resizedBytes = baos.toByteArray();
+                resizedBitmap.recycle();
+            } catch (OutOfMemoryError e) {
+                mLogger.warning("MotionJPEG Frame could not be decoded to bitmap for: " + e.getMessage());
             }
-
-            int w = mWidth != null ? mWidth : src.getWidth();
-            int h = mHeight != null ? mHeight : src.getHeight();
-
-            Bitmap resizedBitmap = Bitmap.createScaledBitmap(src, w, h, true);
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            resizedBitmap.compress(Bitmap.CompressFormat.JPEG, 100, baos);
-            byte[] resizedBytes = baos.toByteArray();
-            resizedBitmap.recycle();
             return resizedBytes;
         }
 

--- a/dConnectDevicePlugin/dConnectDeviceUVC/libuvccamera/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/libuvccamera/build.gradle
@@ -22,6 +22,11 @@ android {
             jni.srcDirs = []
         }
     }
+    externalNativeBuild {
+        ndkBuild {
+            path 'src/main/jni/Android.mk'
+        }
+    }
 }
 
 dependencies {

--- a/dConnectDevicePlugin/dConnectDeviceUVC/libuvccamera/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/libuvccamera/build.gradle
@@ -22,11 +22,6 @@ android {
             jni.srcDirs = []
         }
     }
-    externalNativeBuild {
-        ndkBuild {
-            path 'src/main/jni/Android.mk'
-        }
-    }
 }
 
 dependencies {

--- a/dConnectDevicePlugin/dConnectDeviceUVC/libuvccamera/src/main/jni/Application.mk
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/libuvccamera/src/main/jni/Application.mk
@@ -24,7 +24,7 @@
 
 # This is just for mips, if you really needs MSA, un-comment and build with GCC.
 # Note: Supporting GCC on NDK is already deprecated and GCC will be removed from NDK soon.
-#NDK_TOOLCHAIN_VERSION := 4.9
+NDK_TOOLCHAIN_VERSION := 4.9
 
 APP_PLATFORM := android-14
 APP_ABI := armeabi armeabi-v7a x86 mips

--- a/dConnectDevicePlugin/dConnectDeviceUVC/libuvccamera/src/main/jni/UVCCamera/Parameters.cpp
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/libuvccamera/src/main/jni/UVCCamera/Parameters.cpp
@@ -365,6 +365,11 @@ char *UVCDiags::getSupportedSize(const uvc_device_handle_t *deviceHandle) {
 						switch (fmt_desc->bDescriptorSubtype) {
 						case UVC_VS_FORMAT_UNCOMPRESSED:
 						case UVC_VS_FORMAT_MJPEG:
+                        // MODIFIED--->
+                        case UVC_VS_FORMAT_MPEG2TS:
+                        case UVC_VS_FORMAT_DV:
+                        case UVC_VS_FORMAT_FRAME_BASED:
+                            // <---MODIFIED
 							write(writer, "index", fmt_desc->bFormatIndex);
 							write(writer, "type", fmt_desc->bDescriptorSubtype);
 							write(writer, "default", fmt_desc->bDefaultFrameIndex);

--- a/dConnectDevicePlugin/dConnectDeviceUVC/libuvccamera/src/main/jni/UVCCamera/UVCPreview.cpp
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/libuvccamera/src/main/jni/UVCCamera/UVCPreview.cpp
@@ -578,16 +578,16 @@ void UVCPreview::do_preview(uvc_stream_ctrl_t *ctrl) {
                     // (Motion-JPEG as AVI movie is often omitted huffman tables.)
                     do_preview_pass_through_mjpeg(env, frame_mjpeg);
 
-
-					frame = get_frame(frame_mjpeg->width * frame_mjpeg->height * 2);
-					result = uvc_mjpeg2yuyv(frame_mjpeg, frame);   // MJPEG => yuyv
-					recycle_frame(frame_mjpeg);
-					if (LIKELY(!result)) {
-						frame = draw_preview_one(frame, &mPreviewWindow, uvc_any2rgbx, 4);
-						addCaptureFrame(frame);
-					} else {
-						recycle_frame(frame);
-					}
+                    // MODIFIED:
+					// frame = get_frame(frame_mjpeg->width * frame_mjpeg->height * 2);
+					// result = uvc_mjpeg2yuyv(frame_mjpeg, frame);   // MJPEG => yuyv
+					//recycle_frame(frame_mjpeg);
+					//if (LIKELY(!result)) {
+					//	frame = draw_preview_one(frame, &mPreviewWindow, uvc_any2rgbx, 4);
+					//	addCaptureFrame(frame);
+					//} else {
+					//	recycle_frame(frame);
+					//}
 				}
 			}
 		} else {

--- a/dConnectDevicePlugin/dConnectDeviceUVC/libuvccamera/src/main/jni/UVCCamera/UVCPreview.cpp
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/libuvccamera/src/main/jni/UVCCamera/UVCPreview.cpp
@@ -41,6 +41,9 @@
 #include "UVCPreview.h"
 #include "libuvc_internal.h"
 #include "jpeglib.h"
+// MODIFIED
+#define MJPEG_FRAME_THRESHOLD_BYTE 10000
+//
 #define	LOCAL_DEBUG 0
 #define MAX_FRAME 4
 #define PREVIEW_PIXEL_BYTES 4	// RGBA/RGBX
@@ -581,6 +584,13 @@ void UVCPreview::do_preview(uvc_stream_ctrl_t *ctrl) {
                     // MODIFIED:
 					// frame = get_frame(frame_mjpeg->width * frame_mjpeg->height * 2);
 					// result = uvc_mjpeg2yuyv(frame_mjpeg, frame);   // MJPEG => yuyv
+                    if (frame_mjpeg->data_bytes > MJPEG_FRAME_THRESHOLD_BYTE) {  // XXX
+                        //Restart streaming
+                        uvc_stop_streaming(mDeviceHandle);
+                        uvc_start_streaming_bandwidth(
+                                mDeviceHandle, ctrl, uvc_preview_frame_callback, (void *) this,
+                                requestBandwidth, 0);
+                    }
 					recycle_frame(frame_mjpeg);
 					//if (LIKELY(!result)) {
 					//	frame = draw_preview_one(frame, &mPreviewWindow, uvc_any2rgbx, 4);

--- a/dConnectDevicePlugin/dConnectDeviceUVC/libuvccamera/src/main/jni/UVCCamera/UVCPreview.cpp
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/libuvccamera/src/main/jni/UVCCamera/UVCPreview.cpp
@@ -581,7 +581,7 @@ void UVCPreview::do_preview(uvc_stream_ctrl_t *ctrl) {
                     // MODIFIED:
 					// frame = get_frame(frame_mjpeg->width * frame_mjpeg->height * 2);
 					// result = uvc_mjpeg2yuyv(frame_mjpeg, frame);   // MJPEG => yuyv
-					//recycle_frame(frame_mjpeg);
+					recycle_frame(frame_mjpeg);
 					//if (LIKELY(!result)) {
 					//	frame = draw_preview_one(frame, &mPreviewWindow, uvc_any2rgbx, 4);
 					//	addCaptureFrame(frame);

--- a/dConnectDevicePlugin/dConnectDeviceUVC/libuvccamera/src/main/jni/libjpeg-turbo-1.5.0/jchuff.c
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/libuvccamera/src/main/jni/libjpeg-turbo-1.5.0/jchuff.c
@@ -383,10 +383,11 @@ dump_buffer (working_state *state)
   } \
 }
 
+/* MODIFIED
 #if !defined(_WIN32) && !defined(SIZEOF_SIZE_T)
 #error Cannot determine word size
 #endif
-
+*/
 #if SIZEOF_SIZE_T==8 || defined(_WIN64)
 
 #define EMIT_BITS(code, size) { \

--- a/dConnectDevicePlugin/dConnectDeviceUVC/libuvccamera/src/main/jni/libjpeg-turbo-1.5.0/jdhuff.h
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/libuvccamera/src/main/jni/libjpeg-turbo-1.5.0/jdhuff.h
@@ -70,10 +70,11 @@ EXTERN(void) jpeg_make_d_derived_tbl
  * necessary.
  */
 
+/* MODIFIED
 #if !defined(_WIN32) && !defined(SIZEOF_SIZE_T)
 #error Cannot determine word size
 #endif
-
+*/
 #if SIZEOF_SIZE_T==8 || defined(_WIN64)
 
 typedef size_t bit_buf_type;            /* type of bit-extraction buffer */


### PR DESCRIPTION
## 修正内容
* UVCプラグインの解像度解析処理の不具合修正。
* WebRTCと組み合わせた時にOOMが出る現象の一時対応。
* AndroidStudio側でUVCCameraのソースコードを編集できるようにした。
#311 対応。