### PR TITLE
1つのプラグインに対してBinderとBroadcastの両方で通信してしまう問題を修正

### DIFF
--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/localoauth/DevicePluginXml.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/localoauth/DevicePluginXml.java
@@ -7,6 +7,10 @@
 package org.deviceconnect.android.localoauth;
 
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -14,13 +18,53 @@ import java.util.Map;
  *
  * @author NTT DOCOMO, INC.
  */
-public class DevicePluginXml {
+public class DevicePluginXml implements Parcelable {
 
     /** API仕様定義ファイルを格納するディレクトリへのパス. */
     String mSpecPath;
 
     /** プラグインのサポートするプロファイルリストの宣言. */
     Map<String, DevicePluginXmlProfile> mSupportedProfiles;
+
+    /**
+     * Android SDKによって割り当てられた XML リソースID.
+     * 同一プラグインに対する設定かどうかの判定に使用する.
+     */
+    private final int mResourceId;
+
+    /**
+     * コンストラクタ.
+     *
+     * @param resId XMLリソースID
+     */
+    DevicePluginXml(final int resId) {
+        mResourceId = resId;
+    }
+
+    /**
+     * コンストラクタ.
+     * @deprecated 別のコンストラクタ DevicePluginXml(int) を使用することを推奨
+     */
+    public DevicePluginXml() {
+        this(-1);
+    }
+
+    /**
+     * XMLリソースIDを取得する.
+     * @return XMLリソースID
+     */
+    public int getResourceId() {
+        return mResourceId;
+    }
+
+    /**
+     * 同一プラグインに対する設定かどうかを返す.
+     * @param plugin プラグイン情報
+     * @return 同一プラグインに対する設定である場合は<code>true</code>、そうでない場合は<code>false</code>
+     */
+    public boolean isSamePlugin(final DevicePluginXml plugin) {
+        return getResourceId() == plugin.getResourceId();
+    }
 
     /**
      * API仕様定義ファイルを格納するディレクトリへのパスを取得する.
@@ -37,4 +81,44 @@ public class DevicePluginXml {
     public Map<String, DevicePluginXmlProfile> getSupportedProfiles() {
         return mSupportedProfiles;
     }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(this.mSpecPath);
+        dest.writeInt(this.mSupportedProfiles.size());
+        for (Map.Entry<String, DevicePluginXmlProfile> entry : this.mSupportedProfiles.entrySet()) {
+            dest.writeString(entry.getKey());
+            dest.writeParcelable(entry.getValue(), flags);
+        }
+        dest.writeInt(this.mResourceId);
+    }
+
+    protected DevicePluginXml(Parcel in) {
+        this.mSpecPath = in.readString();
+        int mSupportedProfilesSize = in.readInt();
+        this.mSupportedProfiles = new HashMap<String, DevicePluginXmlProfile>(mSupportedProfilesSize);
+        for (int i = 0; i < mSupportedProfilesSize; i++) {
+            String key = in.readString();
+            DevicePluginXmlProfile value = in.readParcelable(DevicePluginXmlProfile.class.getClassLoader());
+            this.mSupportedProfiles.put(key, value);
+        }
+        this.mResourceId = in.readInt();
+    }
+
+    public static final Creator<DevicePluginXml> CREATOR = new Creator<DevicePluginXml>() {
+        @Override
+        public DevicePluginXml createFromParcel(Parcel source) {
+            return new DevicePluginXml(source);
+        }
+
+        @Override
+        public DevicePluginXml[] newArray(int size) {
+            return new DevicePluginXml[size];
+        }
+    };
 }

--- a/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/localoauth/DevicePluginXmlUtil.java
+++ b/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk/src/main/java/org/deviceconnect/android/localoauth/DevicePluginXmlUtil.java
@@ -53,7 +53,8 @@ public final class DevicePluginXmlUtil {
         XmlResourceParser xrp = pluginComponent.loadXmlMetaData(pkgMgr, PLUGIN_META_DATA);
         try {
             if (xrp != null) {
-                return parseDevicePluginXML(xrp);
+                int xmlId = pluginComponent.metaData.getInt(PLUGIN_META_DATA);
+                return parseDevicePluginXML(xmlId, xrp);
             }
         } catch (XmlPullParserException e) {
             if (BuildConfig.DEBUG) {
@@ -173,13 +174,15 @@ public final class DevicePluginXmlUtil {
 
     /**
      * xml/deviceplugin.xmlの解析を行う.
-     * 
-     * @param xrp xmlパーサ
-     * @throws XmlPullParserException xmlの解析に失敗した場合に発生
-     * @throws IOException xmlの読み込みに失敗した場合
+     *
+     * @param resId XMLファイルのリソースID
+     * @param xrp XMLパーサ
+     * @throws XmlPullParserException XMLファイルの解析に失敗した場合に発生
+     * @throws IOException XMLファイルの読み込みに失敗した場合
      * @return {@link DevicePluginXml}クラスのインスタンス
      */
-    private static DevicePluginXml parseDevicePluginXML(final XmlResourceParser xrp)
+    private static DevicePluginXml parseDevicePluginXML(final int resId,
+                                                        final XmlResourceParser xrp)
             throws XmlPullParserException, IOException {
         Map<String, DevicePluginXmlProfile> list = new HashMap<String, DevicePluginXmlProfile>();
 
@@ -201,7 +204,7 @@ public final class DevicePluginXmlUtil {
 
             if ("deviceplugin-provider".equals(tagName)) {
                 if (eventType == XmlPullParser.START_TAG) {
-                    xml = new DevicePluginXml();
+                    xml = new DevicePluginXml(resId);
                     specPath = xrp.getAttributeValue(null, "spec-path");
                 }
             } else if ("profile".equals(tagName)) {


### PR DESCRIPTION
# 修正内容
プラグイン側のAndroidManifest.xmlで、<meta-data>によって全く同一のXMLを指定している ComponentInfo が複数ある場合は、
・その中から ServiceInfo を優先して選択し、ReceiverInfo は無視します。
・ServiceInfo または ReceiverInfo が複数あって、上記の条件で絞りきれない場合は、さらにその中から任意のものを選択します。