### PR TITLE
全プラグイン再起動時に通信エラーが発生する問題を修正

### DIFF
--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/DevicePluginInfoFragment.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/DevicePluginInfoFragment.java
@@ -294,7 +294,7 @@ public class DevicePluginInfoFragment extends Fragment {
                 }
                 List<DevicePlugin> plugins = mgr.getDevicePlugins();
                 for (DevicePlugin plugin : plugins) {
-                    if (plugin.getPackageName().equals(mPluginInfo.getPackageName())
+                    if (plugin.isEnabled() && plugin.getPackageName().equals(mPluginInfo.getPackageName())
                             && plugin.getPluginId() != null) {
                         restartDevicePlugin(plugin);
                         break;

--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/RestartingDialogFragment.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/RestartingDialogFragment.java
@@ -74,13 +74,6 @@ public class RestartingDialogFragment extends DialogFragment {
             @Override
             protected Void doInBackground(final Void... params) {
                 DevicePluginManager mgr = activity.getPluginManager();
-                try {
-                    mgr.createDevicePluginList();
-                } catch (PluginDetectionException e) {
-                    showPluginDetectionErrorDialog(activity, e);
-                    return null;
-                }
-
                 List<DevicePlugin> plugins = mgr.getDevicePlugins();
                 for (DevicePlugin plugin : plugins) {
                     if (plugin.isEnabled() && plugin.getPluginId() != null) {

--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/RestartingDialogFragment.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/RestartingDialogFragment.java
@@ -83,7 +83,7 @@ public class RestartingDialogFragment extends DialogFragment {
 
                 List<DevicePlugin> plugins = mgr.getDevicePlugins();
                 for (DevicePlugin plugin : plugins) {
-                    if (plugin.getPluginId() != null) {
+                    if (plugin.isEnabled() && plugin.getPluginId() != null) {
                         if (packageName == null || packageName.equals(plugin.getPackageName())) {
                             Intent request = new Intent();
                             request.setComponent(plugin.getComponentName());


### PR DESCRIPTION
* 修正内容
Device Connect Managerの設定画面上で全プラグイン再起動を実行した時に、実行時例外が発生する問題を修正。

PackageManager#getInstalledServices実行時に発生していたため、全プラグイン再起動のときにそれを実行しないようにした。