### PR TITLE
SpheroプラグインにてBluetooth名がnullのデバイスがペアリングされている場合の不具合修正

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceSphero/app/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceSphero/app/build.gradle
@@ -16,7 +16,7 @@ android {
     }
     defaultConfig {
         applicationId "org.deviceconnect.android.deviceplugin.sphero"
-        minSdkVersion 14
+        minSdkVersion 18
         targetSdkVersion 23
         versionCode 1
         versionName getVersionName()

--- a/dConnectDevicePlugin/dConnectDeviceSphero/app/src/main/java/org/deviceconnect/android/deviceplugin/sphero/SpheroDeviceService.java
+++ b/dConnectDevicePlugin/dConnectDeviceSphero/app/src/main/java/org/deviceconnect/android/deviceplugin/sphero/SpheroDeviceService.java
@@ -144,7 +144,7 @@ public class SpheroDeviceService extends DConnectMessageService implements Devic
         BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
         Set<BluetoothDevice> pairedDevices = adapter.getBondedDevices();
         for (BluetoothDevice device : pairedDevices) {
-            if (device.getName().contains("Sphero")) {
+            if (device.getName() != null && device.getName().contains("Sphero")) {
                 PermissionUtility.requestPermissions(SpheroDeviceService.this, mHandler,
                         BleUtils.BLE_PERMISSIONS,
                         new PermissionUtility.PermissionRequestCallback() {


### PR DESCRIPTION
## 修正内容
* SpheroプラグインにてBluetooth名がnullのデバイスがペアリングされている場合の不具合修正
* SpheroSDKの[サンプル](https://github.com/orbotix/Sphero-Android-SDK/blob/master/samples/ButtonDrive/build.gradle#L9)がminSDKVersion18なので、それに合わせた。