### PR TITLE
タッチスクリーンを備えていない（notouch）端末用にユーザーインターフェースを調整した。

### DIFF
--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/ServiceListActivity.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/ServiceListActivity.java
@@ -177,9 +177,17 @@ public class ServiceListActivity extends BaseSettingActivity implements AlertDia
                 }
 
                 DConnectService managerService = getManagerService();
-                if (mSwitchAction != null) {
-                    mSwitchAction.setChecked(managerService.isRunning());
+                if (mSwitchAction == null) {
+                    mSwitchAction = (Switch) findViewById(R.id.activity_service_list_manager_switch);
+                    mSwitchAction.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                        @Override
+                        public void onCheckedChanged(final CompoundButton buttonView, final boolean isChecked) {
+                            switchDConnectServer(isChecked);
+                        }
+                    });
                 }
+                mSwitchAction.setChecked(managerService.isRunning());
+
                 if (managerService.isRunning()) {
                     reloadServiceList();
                 }
@@ -201,7 +209,12 @@ public class ServiceListActivity extends BaseSettingActivity implements AlertDia
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.activity_service_list, menu);
 
-        mSwitchAction = (Switch) menu.findItem(R.id.activity_service_manager_power).getActionView();
+        MenuItem managerSwitch = menu.findItem(R.id.activity_service_manager_power);
+        if (managerSwitch == null) {
+            return super.onCreateOptionsMenu(menu);
+        }
+
+        mSwitchAction = (Switch) managerSwitch.getActionView();
         if (mSwitchAction != null) {
             DisplayMetrics metrics = getResources().getDisplayMetrics();
             mSwitchAction.setPadding((int)(12 * metrics.density), 0, (int)(12 * metrics.density), 0);

--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/ServiceListActivity.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/ServiceListActivity.java
@@ -130,6 +130,17 @@ public class ServiceListActivity extends BaseSettingActivity implements AlertDia
     private Switch mSwitchAction;
 
     /**
+     * Device Connect Managerの起動スイッチのリスナー
+     */
+    private final CompoundButton.OnCheckedChangeListener mSwitchActionListener =
+            new CompoundButton.OnCheckedChangeListener() {
+                @Override
+                public void onCheckedChanged(final CompoundButton buttonView, final boolean isChecked) {
+                    switchDConnectServer(isChecked);
+                }
+            };
+
+    /**
      * ガイドの表示ページ.
      */
     private int mPageIndex;
@@ -146,6 +157,7 @@ public class ServiceListActivity extends BaseSettingActivity implements AlertDia
 
         mServiceListGridView = (GridView) findViewById(R.id.activity_service_list_grid_view);
         mButtonReloadServiceList = (Button) findViewById(R.id.activity_service_list_search_button);
+        mSwitchAction = (Switch) findViewById(R.id.activity_service_list_manager_switch);
 
         mSettings = ((DConnectApplication) getApplication()).getSettings();
 
@@ -188,16 +200,10 @@ public class ServiceListActivity extends BaseSettingActivity implements AlertDia
                 }
 
                 DConnectService managerService = getManagerService();
-                if (mSwitchAction == null) {
-                    mSwitchAction = (Switch) findViewById(R.id.activity_service_list_manager_switch);
-                    mSwitchAction.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-                        @Override
-                        public void onCheckedChanged(final CompoundButton buttonView, final boolean isChecked) {
-                            switchDConnectServer(isChecked);
-                        }
-                    });
+                if (mSwitchAction != null) {
+                    mSwitchAction.setOnCheckedChangeListener(mSwitchActionListener);
+                    mSwitchAction.setChecked(managerService.isRunning());
                 }
-                mSwitchAction.setChecked(managerService.isRunning());
 
                 if (managerService.isRunning()) {
                     reloadServiceList();
@@ -225,16 +231,13 @@ public class ServiceListActivity extends BaseSettingActivity implements AlertDia
             return super.onCreateOptionsMenu(menu);
         }
 
-        mSwitchAction = (Switch) managerSwitch.getActionView();
-        if (mSwitchAction != null) {
+        Switch switchAction = (Switch) managerSwitch.getActionView();
+        if (switchAction != null) {
+            mSwitchAction = switchAction;
+
             DisplayMetrics metrics = getResources().getDisplayMetrics();
-            mSwitchAction.setPadding((int)(12 * metrics.density), 0, (int)(12 * metrics.density), 0);
-            mSwitchAction.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-                @Override
-                public void onCheckedChanged(final CompoundButton buttonView, final boolean isChecked) {
-                    switchDConnectServer(isChecked);
-                }
-            });
+            mSwitchAction.setPadding((int) (12 * metrics.density), 0, (int) (12 * metrics.density), 0);
+            mSwitchAction.setOnCheckedChangeListener(mSwitchActionListener);
 
             DConnectService managerService = getManagerService();
             if (managerService != null) {

--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/ServiceListActivity.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/ServiceListActivity.java
@@ -110,6 +110,16 @@ public class ServiceListActivity extends BaseSettingActivity implements AlertDia
     private ServiceContainer mSelectedService;
 
     /**
+     * サービスのリスト表示.
+     */
+    GridView mServiceListGridView;
+
+    /**
+     * サービスリストの再読み込みボタン.
+     */
+    Button mButtonReloadServiceList;
+
+    /**
      * ハンドラ.
      */
     private Handler mHandler = new Handler();
@@ -134,6 +144,9 @@ public class ServiceListActivity extends BaseSettingActivity implements AlertDia
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_service_list);
 
+        mServiceListGridView = (GridView) findViewById(R.id.activity_service_list_grid_view);
+        mButtonReloadServiceList = (Button) findViewById(R.id.activity_service_list_search_button);
+
         mSettings = ((DConnectApplication) getApplication()).getSettings();
 
         if (loadGuideSettings(this)) {
@@ -148,16 +161,15 @@ public class ServiceListActivity extends BaseSettingActivity implements AlertDia
             public void run() {
                 mServiceAdapter = new ServiceAdapter(getPluginManager());
 
-                GridView gridView = (GridView) findViewById(R.id.activity_service_list_grid_view);
-                if (gridView != null) {
-                    gridView.setAdapter(mServiceAdapter);
-                    gridView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+                if (mServiceListGridView != null) {
+                    mServiceListGridView.setAdapter(mServiceAdapter);
+                    mServiceListGridView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
                         @Override
                         public void onItemClick(final AdapterView<?> parent, final View view, final int position, final long id) {
                             openServiceInfo(position);
                         }
                     });
-                    gridView.setOnItemLongClickListener(new AdapterView.OnItemLongClickListener() {
+                    mServiceListGridView.setOnItemLongClickListener(new AdapterView.OnItemLongClickListener() {
                         @Override
                         public boolean onItemLongClick(final AdapterView<?> parent, final View view, final int position, final long id) {
                             openPluginSetting(position);
@@ -166,9 +178,8 @@ public class ServiceListActivity extends BaseSettingActivity implements AlertDia
                     });
                 }
 
-                Button btn = (Button) findViewById(R.id.activity_service_list_search_button);
-                if (btn != null) {
-                    btn.setOnClickListener(new View.OnClickListener() {
+                if (mButtonReloadServiceList != null) {
+                    mButtonReloadServiceList.setOnClickListener(new View.OnClickListener() {
                         @Override
                         public void onClick(final View v) {
                             reloadServiceList();

--- a/dConnectManager/dConnectManager/app/src/main/res/layout-notouch/activity_service_list.xml
+++ b/dConnectManager/dConnectManager/app/src/main/res/layout-notouch/activity_service_list.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+    <GridView
+            android:id="@+id/activity_service_list_grid_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_above="@+id/activity_service_list_buttons_container"
+            android:layout_margin="8dp"
+            android:columnWidth="80dp"
+            android:gravity="center"
+            android:horizontalSpacing="8dp"
+            android:minHeight="100dp"
+            android:numColumns="auto_fit"
+            android:stretchMode="columnWidth"
+            android:verticalSpacing="8dp" />
+
+    <LinearLayout
+            android:id="@+id/activity_service_list_buttons_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true">
+
+        <Switch
+                android:id="@+id/activity_service_list_manager_switch"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="8dp"
+                android:layout_weight="1"
+                android:text="@string/app_name" />
+
+        <Button
+                android:id="@+id/activity_service_list_search_button"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="8dp"
+                android:layout_weight="1"
+                android:text="@string/activity_service_list_search" />
+
+    </LinearLayout>
+
+    <FrameLayout
+            android:id="@+id/activity_service_no_service"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone">
+
+        <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:gravity="center"
+                android:text="@string/activity_service_list_no_service"
+                android:textColor="#444" />
+    </FrameLayout>
+
+</RelativeLayout>

--- a/dConnectManager/dConnectManager/app/src/main/res/layout/activity_service_list.xml
+++ b/dConnectManager/dConnectManager/app/src/main/res/layout/activity_service_list.xml
@@ -42,109 +42,11 @@
             android:textColor="#444"/>
     </FrameLayout>
 
-
-    <FrameLayout
-        android:id="@+id/activity_service_guide"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone">
-
-        <View
+    <include
+            android:id="@+id/activity_service_guide"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:background="#88000000"/>
-
-        <LinearLayout
-            android:id="@+id/activity_service_guide_1"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="right"
-            android:layout_marginTop="-8dp"
-            android:orientation="vertical">
-
-            <View
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:layout_gravity="center_horizontal"
-                android:layout_marginRight="-64dp"
-                android:layout_marginTop="16dp"
-                android:background="@android:color/white"
-                android:rotation="45"/>
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:layout_marginLeft="16dp"
-                android:layout_marginRight="16dp"
-                android:layout_marginTop="-16dp"
-                android:background="@drawable/manager_bg_balloon"
-                android:maxWidth="320dp"
-                android:padding="16dp"
-                android:text="@string/activity_service_list_guide_1"
-                android:textColor="@android:color/black"
-                android:textSize="18sp"/>
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/activity_service_guide_2"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="right"
-            android:layout_marginTop="-8dp"
-            android:orientation="vertical"
-            android:visibility="gone">
-
-            <View
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:layout_gravity="right"
-                android:layout_marginRight="24dp"
-                android:layout_marginTop="16dp"
-                android:background="@android:color/white"
-                android:rotation="45"/>
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:layout_marginLeft="16dp"
-                android:layout_marginRight="16dp"
-                android:layout_marginTop="-16dp"
-                android:background="@drawable/manager_bg_balloon"
-                android:maxWidth="320dp"
-                android:padding="16dp"
-                android:text="@string/activity_service_list_guide_2"
-                android:textColor="@android:color/black"
-                android:textSize="18sp"/>
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="bottom|center_horizontal"
-            android:layout_margin="24dp"
-            android:gravity="center_horizontal"
-            android:orientation="vertical">
-
-            <CheckBox
-                android:id="@+id/activity_service_guide_checkbox"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_margin="12dp"
-                android:checked="true"
-                android:text="@string/activity_service_list_checkbox"
-                android:nextFocusDown="@+id/activity_service_guide_button"
-                android:nextFocusRight="@+id/activity_service_guide_button"
-                android:textColor="@android:color/white"/>
-
-            <Button
-                android:id="@+id/activity_service_guide_button"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/activity_service_list_guide_next"/>
-        </LinearLayout>
-
-    </FrameLayout>
+            layout="@layout/service_guide"
+        />
 
 </RelativeLayout>

--- a/dConnectManager/dConnectManager/app/src/main/res/layout/service_guide.xml
+++ b/dConnectManager/dConnectManager/app/src/main/res/layout/service_guide.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone">
+
+    <View
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="#88000000" />
+
+    <LinearLayout
+            android:id="@+id/activity_service_guide_1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="right"
+            android:layout_marginTop="-8dp"
+            android:orientation="vertical">
+
+        <View
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginRight="-64dp"
+                android:layout_marginTop="16dp"
+                android:background="@android:color/white"
+                android:rotation="45" />
+
+        <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:layout_marginTop="-16dp"
+                android:background="@drawable/manager_bg_balloon"
+                android:maxWidth="320dp"
+                android:padding="16dp"
+                android:text="@string/activity_service_list_guide_1"
+                android:textColor="@android:color/black"
+                android:textSize="18sp" />
+    </LinearLayout>
+
+    <LinearLayout
+            android:id="@+id/activity_service_guide_2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="right"
+            android:layout_marginTop="-8dp"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+        <View
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_gravity="right"
+                android:layout_marginRight="24dp"
+                android:layout_marginTop="16dp"
+                android:background="@android:color/white"
+                android:rotation="45" />
+
+        <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:layout_marginTop="-16dp"
+                android:background="@drawable/manager_bg_balloon"
+                android:maxWidth="320dp"
+                android:padding="16dp"
+                android:text="@string/activity_service_list_guide_2"
+                android:textColor="@android:color/black"
+                android:textSize="18sp" />
+    </LinearLayout>
+
+    <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|center_horizontal"
+            android:layout_margin="24dp"
+            android:gravity="center_horizontal"
+            android:orientation="vertical">
+
+        <CheckBox
+                android:id="@+id/activity_service_guide_checkbox"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="12dp"
+                android:checked="true"
+                android:text="@string/activity_service_list_checkbox"
+                android:nextFocusDown="@+id/activity_service_guide_button"
+                android:nextFocusRight="@+id/activity_service_guide_button"
+                android:textColor="@android:color/white" />
+
+        <Button
+                android:id="@+id/activity_service_guide_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/activity_service_list_guide_next" />
+    </LinearLayout>
+
+</FrameLayout>
+

--- a/dConnectManager/dConnectManager/app/src/main/res/menu-notouch/activity_service_list.xml
+++ b/dConnectManager/dConnectManager/app/src/main/res/menu-notouch/activity_service_list.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+            android:id="@+id/activity_service_menu_item_settings"
+            app:showAsAction="never"
+            android:title="@string/activity_service_menu_settings" />
+
+    <item
+            android:id="@+id/activity_service_menu_item_help"
+            app:showAsAction="never"
+            android:title="@string/activity_service_menu_help" />
+</menu>


### PR DESCRIPTION
サービスリスト画面に-notouchリソースを追加。
notouchの場合はアクションバーにあるサービスの切り替えスイッチをフォーカス移動できる画面下に表示する。

なお、起動時のガイドについては画面が崩れるため表示しない。