### PR TITLE
Slack認証処理の修正

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceSlackMessageHook/slack-plugin/src/main/java/com/codebutler/android_websockets/WebSocketClient.java
+++ b/dConnectDevicePlugin/dConnectDeviceSlackMessageHook/slack-plugin/src/main/java/com/codebutler/android_websockets/WebSocketClient.java
@@ -117,7 +117,7 @@ public class WebSocketClient {
 
                     while (!TextUtils.isEmpty(line = readLine(stream))) {
                         Header header = parseHeader(line);
-                        if (header.getName().equals("Sec-WebSocket-Accept")) {
+                        if (header.getName().equalsIgnoreCase("Sec-WebSocket-Accept")) {
                             String expected = createSecretValidation(secret);
                             String actual = header.getValue().trim();
 


### PR DESCRIPTION
## 更新内容
* Slack認証処理時にヘッダーの名前が違うことにより通信が失敗していた件の修正。