### PR TITLE
Android ThingsでWebSocketリストにWebSocketの情報が表示されない不具合の修正

### DIFF
--- a/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/WebSocketListActivity.java
+++ b/dConnectManager/dConnectManager/app/src/main/java/org/deviceconnect/android/manager/setting/WebSocketListActivity.java
@@ -79,6 +79,7 @@ public class WebSocketListActivity extends BaseSettingActivity implements AlertD
     protected void onManagerBonded(final DConnectService manager) {
         mWebSocketInfoAdapter.setWebSocketInfoList(getWebSocketInfoManager().getWebSocketInfos());
         getWebSocketInfoManager().addOnWebSocketEventListener(this);
+        mWebSocketInfoAdapter.notifyDataSetChanged();
     }
 
     @Override


### PR DESCRIPTION
## 更新内容
* Android ThingsでWebSocketリストにWebSocketの情報が表示されない不具合の修正