### PR TITLE
HueプラグインをEthernet経由でも設定できるようにした

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHue/app/src/main/java/org/deviceconnect/android/deviceplugin/hue/db/HueManager.java
+++ b/dConnectDevicePlugin/dConnectDeviceHue/app/src/main/java/org/deviceconnect/android/deviceplugin/hue/db/HueManager.java
@@ -377,9 +377,10 @@ public enum HueManager {
                 }
             }
         }
-
-        PHBridgeSearchManager sm = (PHBridgeSearchManager) mHueSDK.getSDKService(PHHueSDK.SEARCH_BRIDGE);
-        sm.search(true, true);
+        if (mHueSDK != null) {
+            PHBridgeSearchManager sm = (PHBridgeSearchManager) mHueSDK.getSDKService(PHHueSDK.SEARCH_BRIDGE);
+            sm.search(true, true);
+        }
     }
     /**
      * DBに格納されているアクセスポイント情報とライトを削除します.

--- a/dConnectDevicePlugin/dConnectDeviceHue/app/src/main/java/org/deviceconnect/android/deviceplugin/hue/profile/HueDeviceProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceHue/app/src/main/java/org/deviceconnect/android/deviceplugin/hue/profile/HueDeviceProfile.java
@@ -8,16 +8,22 @@ package org.deviceconnect.android.deviceplugin.hue.profile;
 
 import android.content.Context;
 import android.content.Intent;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.net.wifi.WifiManager;
 
+import com.philips.lighting.hue.listener.PHLightListener;
 import com.philips.lighting.hue.sdk.PHAccessPoint;
 import com.philips.lighting.hue.sdk.PHSDKListener;
 import com.philips.lighting.model.PHBridge;
+import com.philips.lighting.model.PHBridgeResource;
+import com.philips.lighting.model.PHHueError;
 import com.philips.lighting.model.PHHueParsingError;
 import com.philips.lighting.model.PHLight;
 
 import org.deviceconnect.android.deviceplugin.hue.HueDeviceService;
 import org.deviceconnect.android.deviceplugin.hue.db.HueManager;
+import org.deviceconnect.android.deviceplugin.hue.service.HueLightService;
 import org.deviceconnect.android.message.MessageUtils;
 import org.deviceconnect.android.profile.DConnectProfile;
 import org.deviceconnect.android.profile.api.DeleteApi;
@@ -27,6 +33,7 @@ import org.deviceconnect.message.DConnectMessage;
 import org.json.hue.JSONObject;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * スマートデバイスへの接続関連の機能を提供するAPI.
@@ -49,8 +56,8 @@ public class HueDeviceProfile extends DConnectProfile {
         }
         @Override
         public boolean onRequest(final Intent request, final Intent response) {
-            if (!isWifiEnabled()) {
-                MessageUtils.setIllegalDeviceStateError(response, "Please connect to Wifi");
+            if (!isLocalNetworkEnabled()) {
+                MessageUtils.setIllegalDeviceStateError(response, "Please connect to LocalNetwork");
                 return true;
             }
             final String serviceId = getServiceID(request);
@@ -98,6 +105,50 @@ public class HueDeviceProfile extends DConnectProfile {
                 public void onBridgeConnected(final PHBridge phBridge, final String userName) {
                     setResult(response, DConnectMessage.RESULT_OK);
                     sendResponse(response);
+                    new Thread(new Runnable() {
+                        @Override
+                        public void run() {
+                            HueManager.INSTANCE.searchLightAutomatic(new PHLightListener() {
+                                @Override
+                                public void onReceivingLightDetails(PHLight phLight) {
+
+                                }
+
+                                @Override
+                                public void onReceivingLights(List<PHBridgeResource> list) {
+                                    for (PHBridgeResource header : list) {
+                                        DConnectService service
+                                                = ((HueDeviceService) getContext()).getServiceProvider()
+                                                    .getService(serviceId + "_" + header.getIdentifier());
+                                        if (service == null) {
+                                            service = new HueLightService(serviceId, header.getIdentifier(), header.getName());
+                                        }
+                                        service.setOnline(true);
+                                    }
+                                }
+
+                                @Override
+                                public void onSearchComplete() {
+
+                                }
+
+                                @Override
+                                public void onSuccess() {
+
+                                }
+
+                                @Override
+                                public void onError(int i, String s) {
+
+                                }
+
+                                @Override
+                                public void onStateUpdate(Map<String, String> map, List<PHHueError> list) {
+
+                                }
+                            });
+                        }
+                    }).start();
                 }
 
                 @Override
@@ -197,11 +248,18 @@ public class HueDeviceProfile extends DConnectProfile {
     }
 
     /**
-     * Wi-Fi接続設定の状態を取得します.
+     * LocalNetwork接続設定の状態を取得します.
      * @return trueの場合は有効、それ以外の場合は無効
      */
-    private boolean isWifiEnabled() {
-        WifiManager mgr = (WifiManager) getContext().getApplicationContext().getSystemService(Context.WIFI_SERVICE);
-        return mgr.isWifiEnabled();
+    private boolean isLocalNetworkEnabled() {
+        ConnectivityManager convManager = (ConnectivityManager) getContext().getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo info = convManager.getActiveNetworkInfo();
+        boolean isEthernet = false;
+        if (info != null) {
+            return (info.getType() == ConnectivityManager.TYPE_ETHERNET
+                    || info.getType() == ConnectivityManager.TYPE_WIFI);
+        } else {
+            return false;
+        }
     }
 }

--- a/dConnectDevicePlugin/dConnectDeviceHue/app/src/main/java/org/deviceconnect/android/deviceplugin/hue/profile/HueDeviceProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceHue/app/src/main/java/org/deviceconnect/android/deviceplugin/hue/profile/HueDeviceProfile.java
@@ -166,51 +166,44 @@ public class HueDeviceProfile extends DConnectProfile {
      * @param serviceId ブリッジの
      */
     private void searchLight(final String serviceId) {
-
-        new Thread(new Runnable() {
+        HueManager.INSTANCE.searchLightAutomatic(new PHLightListener() {
             @Override
-            public void run() {
-                HueManager.INSTANCE.searchLightAutomatic(new PHLightListener() {
-                    @Override
-                    public void onReceivingLightDetails(PHLight phLight) {
+            public void onReceivingLightDetails(PHLight phLight) {
 
-                    }
-
-                    @Override
-                    public void onReceivingLights(List<PHBridgeResource> list) {
-                        for (PHBridgeResource header : list) {
-                            DConnectService service
-                                    = ((HueDeviceService) getContext()).getServiceProvider()
-                                        .getService(serviceId + "_" + header.getIdentifier());
-                            if (service == null) {
-                                service = new HueLightService(serviceId, header.getIdentifier(), header.getName());
-                                ((HueDeviceService) getContext()).getServiceProvider().addService(service);
-                            }
-                            service.setOnline(true);
-                        }
-                    }
-
-                    @Override
-                    public void onSearchComplete() {
-                        mIsSearchBridge = false;
-                    }
-
-                    @Override
-                    public void onSuccess() {
-                    }
-
-                    @Override
-                    public void onError(int i, String s) {
-
-                    }
-
-                    @Override
-                    public void onStateUpdate(Map<String, String> map, List<PHHueError> list) {
-
-                    }
-                });
             }
-        }).start();
+
+            @Override
+            public void onReceivingLights(List<PHBridgeResource> list) {
+                for (PHBridgeResource header : list) {
+                    DConnectService service
+                            = ((HueDeviceService) getContext()).getServiceProvider()
+                                .getService(serviceId + "_" + header.getIdentifier());
+                    if (service == null) {
+                        service = new HueLightService(serviceId, header.getIdentifier(), header.getName());
+                        ((HueDeviceService) getContext()).getServiceProvider().addService(service);
+                    }
+                    service.setOnline(true);
+                }
+            }
+
+            @Override
+            public void onSearchComplete() {
+                mIsSearchBridge = false;
+            }
+
+            @Override
+            public void onSuccess() {
+            }
+
+            @Override
+            public void onError(int i, String s) {
+            }
+
+            @Override
+            public void onStateUpdate(Map<String, String> map, List<PHHueError> list) {
+
+            }
+        });
     }
 
     /**

--- a/dConnectDevicePlugin/dConnectDeviceHue/app/src/main/java/org/deviceconnect/android/deviceplugin/hue/profile/HueDeviceProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceHue/app/src/main/java/org/deviceconnect/android/deviceplugin/hue/profile/HueDeviceProfile.java
@@ -192,17 +192,16 @@ public class HueDeviceProfile extends DConnectProfile {
 
                     @Override
                     public void onSearchComplete() {
-
+                        mIsSearchBridge = false;
                     }
 
                     @Override
                     public void onSuccess() {
-                        mIsSearchBridge = false;
                     }
 
                     @Override
                     public void onError(int i, String s) {
-                        mIsSearchBridge = false;
+
                     }
 
                     @Override

--- a/dConnectDevicePlugin/dConnectDeviceHue/app/src/main/java/org/deviceconnect/android/deviceplugin/hue/profile/HueDeviceProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceHue/app/src/main/java/org/deviceconnect/android/deviceplugin/hue/profile/HueDeviceProfile.java
@@ -10,7 +10,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
-import android.net.wifi.WifiManager;
 
 import com.philips.lighting.hue.listener.PHLightListener;
 import com.philips.lighting.hue.sdk.PHAccessPoint;
@@ -48,7 +47,7 @@ public class HueDeviceProfile extends DConnectProfile {
     /**
      * Search Lightフラグ.
      */
-    private boolean mIsSearchLight;
+    private boolean mIsSearchBridge;
     /**
      * Hue Bridgeとの接続を行う.
      */
@@ -146,11 +145,11 @@ public class HueDeviceProfile extends DConnectProfile {
                 }
             };
             if (!getService().isOnline()) {
-                if (mIsSearchLight) {
+                if (mIsSearchBridge) {
                     MessageUtils.setIllegalDeviceStateError(response, "Now connecting for Hue bridge.");
                     return true;
                 }
-                mIsSearchLight = true;
+                mIsSearchBridge = true;
                 HueManager.INSTANCE.init(getContext());
                 HueManager.INSTANCE.addSDKListener(mListener);
                 HueManager.INSTANCE.searchHueBridge();
@@ -198,12 +197,12 @@ public class HueDeviceProfile extends DConnectProfile {
 
                     @Override
                     public void onSuccess() {
-                        mIsSearchLight = false;
+                        mIsSearchBridge = false;
                     }
 
                     @Override
                     public void onError(int i, String s) {
-                        mIsSearchLight = false;
+                        mIsSearchBridge = false;
                     }
 
                     @Override

--- a/dConnectDevicePlugin/dConnectDeviceHue/app/src/main/java/org/deviceconnect/android/deviceplugin/hue/service/HueLightService.java
+++ b/dConnectDevicePlugin/dConnectDeviceHue/app/src/main/java/org/deviceconnect/android/deviceplugin/hue/service/HueLightService.java
@@ -24,4 +24,11 @@ public class HueLightService extends DConnectService {
         setNetworkType(NetworkType.WIFI);
         addProfile(new HueLightProfile());
     }
+    public HueLightService(final String ip, final String id, final String name) {
+        //LightのServiceIdは、IPアドレスとライトIDを「:」で区切る
+        super(ip + ":" + id);
+        setName(name);
+        setNetworkType(NetworkType.WIFI);
+        addProfile(new HueLightProfile());
+    }
 }


### PR DESCRIPTION
## 更新内容
* HueプラグインをEthernet経由でも設定できるようにした
* deviceプロファイルでブリッジと接続後、ライトの検索を行うようにした。