### PR TITLE
targetSdkVersion 28 以上の場合、アプリ削除にはパーミッションが必要

### DIFF
--- a/dConnectManager/dConnectManager/dconnect-manager-app/src/main/AndroidManifest.xml
+++ b/dConnectManager/dConnectManager/dconnect-manager-app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
     <uses-permission android:name="android.permission.READ_CALL_LOG" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.ANSWER_PHONE_CALLS" />
+    <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
 
     <application
         android:name="org.deviceconnect.android.manager.DConnectApplication"


### PR DESCRIPTION
# 概要
Android 9 の場合、dConnectManagerの設定画面からプラグインを削除できなくなっていた不具合を修正。

# 動作確認方法
前提: Host以外のプラグインをインストールしていること。
1. Android 9.0 (API 28) のエミュレータを起動。
2. dConnectManager の設定画面からプラグイン一覧を開く。
3. Host以外の任意のプラグインの詳細画面を開く。
4. [削除] ボタンでプラグインを削除できることを確認。