### PR TITLE
デモページ起動時に 403 エラー が表示される問題を修正

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/AndroidManifest.xml
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/AndroidManifest.xml
@@ -99,6 +99,13 @@
             android:launchMode="singleInstance">
         </activity>
 
+        <!-- パーミッション要求画面 -->
+        <activity
+            android:name="org.deviceconnect.android.activity.PermissionRequestActivity"
+            android:exported="false"
+            android:taskAffinity=".permission"
+            android:theme="@style/Theme.Dialog.Transparent"/>
+
         <provider
             android:name="org.deviceconnect.android.deviceplugin.host.file.HostFileProvider"
             android:authorities="org.deviceconnect.android.deviceplugin.host.provider.included"

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/setting/HostDemoPageSettingFragment.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/setting/HostDemoPageSettingFragment.java
@@ -57,7 +57,13 @@ public class HostDemoPageSettingFragment extends BaseHostSettingPageFragment imp
 
     private static final String TAG = "host.dplugin";
 
+    private static final String DOCUMENT_DIR_NAME = "org.deviceconnect.android.manager";
+
     private static final String PLUGIN_DIR_NAME = "org.deviceconnect.android.deviceplugin.host";
+
+    private static final String PREFERENCE_NAME =  "demo_page_info";
+
+    private static final String KEY_PLUGIN_VERSION_NAME = "plugin_version_name";
 
     private static final String CAMERA_DEMO_SHORTCUT_ID = "1";
 
@@ -71,10 +77,6 @@ public class HostDemoPageSettingFragment extends BaseHostSettingPageFragment imp
             Manifest.permission.WRITE_EXTERNAL_STORAGE
     };
 
-    private static final String[] DEMO_PERMISSIONS = {
-            Manifest.permission.CAMERA,
-            Manifest.permission.RECORD_AUDIO
-    };
 
     private Button mDeleteButton;
 
@@ -384,10 +386,6 @@ public class HostDemoPageSettingFragment extends BaseHostSettingPageFragment imp
         PermissionUtility.requestPermissions(context, mHandler, PERMISSIONS, callback);
     }
 
-    private void requestPermissionForDemo(final Context context, final PermissionUtility.PermissionRequestCallback callback) {
-        PermissionUtility.requestPermissions(context, mHandler, DEMO_PERMISSIONS, callback);
-    }
-
     public void onNegativeButton(final String tag, final MessageDialogFragment dialogFragment) {
         // NOP.
     }
@@ -464,18 +462,8 @@ public class HostDemoPageSettingFragment extends BaseHostSettingPageFragment imp
     }
 
     private void openDemoPage(final Activity activity) {
-        requestPermissionForDemo(activity, new PermissionUtility.PermissionRequestCallback() {
-            @Override
-            public void onSuccess() {
-                Intent intent = createDemoPageIntent();
-                activity.startActivity(intent);
-            }
-
-            @Override
-            public void onFail(final @NonNull String deniedPermission) {
-                // NOP.
-            }
-        });
+        Intent intent = createDemoPageIntent();
+        activity.startActivity(intent);
     }
 
     private Intent createDemoPageIntent() {

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/setting/HostDemoPageSettingFragment.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/setting/HostDemoPageSettingFragment.java
@@ -57,13 +57,7 @@ public class HostDemoPageSettingFragment extends BaseHostSettingPageFragment imp
 
     private static final String TAG = "host.dplugin";
 
-    private static final String DOCUMENT_DIR_NAME = "org.deviceconnect.android.manager";
-
     private static final String PLUGIN_DIR_NAME = "org.deviceconnect.android.deviceplugin.host";
-
-    private static final String PREFERENCE_NAME =  "demo_page_info";
-
-    private static final String KEY_PLUGIN_VERSION_NAME = "plugin_version_name";
 
     private static final String CAMERA_DEMO_SHORTCUT_ID = "1";
 
@@ -77,6 +71,10 @@ public class HostDemoPageSettingFragment extends BaseHostSettingPageFragment imp
             Manifest.permission.WRITE_EXTERNAL_STORAGE
     };
 
+    private static final String[] DEMO_PERMISSIONS = {
+            Manifest.permission.CAMERA,
+            Manifest.permission.RECORD_AUDIO
+    };
 
     private Button mDeleteButton;
 
@@ -386,6 +384,10 @@ public class HostDemoPageSettingFragment extends BaseHostSettingPageFragment imp
         PermissionUtility.requestPermissions(context, mHandler, PERMISSIONS, callback);
     }
 
+    private void requestPermissionForDemo(final Context context, final PermissionUtility.PermissionRequestCallback callback) {
+        PermissionUtility.requestPermissions(context, mHandler, DEMO_PERMISSIONS, callback);
+    }
+
     public void onNegativeButton(final String tag, final MessageDialogFragment dialogFragment) {
         // NOP.
     }
@@ -462,8 +464,18 @@ public class HostDemoPageSettingFragment extends BaseHostSettingPageFragment imp
     }
 
     private void openDemoPage(final Activity activity) {
-        Intent intent = createDemoPageIntent();
-        activity.startActivity(intent);
+        requestPermissionForDemo(activity, new PermissionUtility.PermissionRequestCallback() {
+            @Override
+            public void onSuccess() {
+                Intent intent = createDemoPageIntent();
+                activity.startActivity(intent);
+            }
+
+            @Override
+            public void onFail(final @NonNull String deniedPermission) {
+                // NOP.
+            }
+        });
     }
 
     private Intent createDemoPageIntent() {

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/res/values-ja/strings.xml
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/res/values-ja/strings.xml
@@ -65,6 +65,8 @@
     <string name="demo_page_settings_button_overwrite">上書き</string>
     <string name="demo_page_settings_button_open">開く</string>
     <string name="demo_page_settings_button_create_shortcut">ショートカットを作成</string>
+    <string name="demo_page_settings_button_create_shortcut_success">ホーム画面にショートカットを作成しました。</string>
+    <string name="demo_page_settings_button_create_shortcut_error">ホーム画面でのショートカット作成に失敗しました。</string>
     <string name="demo_page_shortcut_label">カメラ</string>
 
     <string name="host_setting_dialog_error_permission">GPSを使用するためのパーミッションが許可されていないために検索できません。\nGPS設定画面から位置情報の許可を取得してください。</string>

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/res/values/strings.xml
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/res/values/strings.xml
@@ -65,6 +65,8 @@
     <string name="demo_page_settings_button_overwrite">Overwrite</string>
     <string name="demo_page_settings_button_open">Open</string>
     <string name="demo_page_settings_button_create_shortcut">Create shortcut</string>
+    <string name="demo_page_settings_button_create_shortcut_success">Created a shortcut to demo on Home.</string>
+    <string name="demo_page_settings_button_create_shortcut_error">Failed to create a shortcut to demo on Home.</string>
     <string name="demo_page_shortcut_label">Camera</string>
 
     <string name="host_setting_dialog_error_permission">It can not be searched because permission to use GPS is not permitted.\nPlease obtain permission of position information from GPS setting screen.</string>

--- a/dConnectDevicePlugin/dConnectDeviceHost/demo/camera/js/main.js
+++ b/dConnectDevicePlugin/dConnectDeviceHost/demo/camera/js/main.js
@@ -531,6 +531,10 @@ app = new Vue({
         imageSize: null,
         frameRate: null
       },
+      
+      // 現在のレコーダー設定のキャッシュ
+      // (設定キャンセル時に設定を戻す時に使う)
+      recorderSettingsCache: null,
 
       connectionError: null
     }
@@ -556,6 +560,8 @@ app = new Vue({
     onLaunched() {},
     openDrawer() { this.showDrawer = true; },
     openRecorderSettingDialog() {
+      this.recorderSettingsCache = JSON.parse(JSON.stringify(this.recorderSettings));
+
       this.dialog = true;
       this.stopPreview();
     },
@@ -612,6 +618,9 @@ app = new Vue({
       return null;
     },
     restoreRecorderOption: function() {
+      // キャンセル時は以前の設定に戻す
+      this.recorderSettings = JSON.parse(JSON.stringify(this.recorderSettingsCache));
+
       this.startPreview();
     },
     changeRecorderOption: function() {

--- a/dConnectDevicePlugin/dConnectDeviceHost/demo/camera/js/main.js
+++ b/dConnectDevicePlugin/dConnectDeviceHost/demo/camera/js/main.js
@@ -814,7 +814,7 @@ function connect() {
       }
     }
     if (hostService === null) {
-      throw new Error('No Host Service.');
+      return Promise.reject({ errorMessage: 'Host サービスが見つかりませんでした。' });
     }
     app.hostService = hostService;
 

--- a/dConnectManager/dConnectManager/dconnect-manager-app/src/main/AndroidManifest.xml
+++ b/dConnectManager/dConnectManager/dconnect-manager-app/src/main/AndroidManifest.xml
@@ -232,6 +232,13 @@
         <!-- アプリ起動を受領し、監視プログラムを立ち上げるためのBroadcastReceiver. -->
         <receiver android:name="org.deviceconnect.android.observer.receiver.ObserverReceiver">
         </receiver>
+
+        <!-- パーミッション要求画面 -->
+        <activity
+            android:name="org.deviceconnect.android.activity.PermissionRequestActivity"
+            android:exported="false"
+            android:taskAffinity=".permission"
+            android:theme="@style/Theme.Dialog.Transparent"/>
     </application>
 
 </manifest>

--- a/dConnectManager/dConnectManager/dconnect-manager-app/src/main/AndroidManifest.xml
+++ b/dConnectManager/dConnectManager/dconnect-manager-app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
     <uses-permission android:name="android.permission.READ_CALL_LOG" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.ANSWER_PHONE_CALLS" />
+    <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
 
     <application
         android:name="org.deviceconnect.android.manager.DConnectApplication"

--- a/dConnectManager/dConnectManager/dconnect-manager-app/src/main/java/org/deviceconnect/android/manager/DConnectHostResolver.java
+++ b/dConnectManager/dConnectManager/dconnect-manager-app/src/main/java/org/deviceconnect/android/manager/DConnectHostResolver.java
@@ -68,7 +68,7 @@ public class DConnectHostResolver extends AppCompatActivity implements AlertDial
 
                 @Override
                 public void onFail(final @NonNull String deniedPermission) {
-                    // NOP.
+                    finish();
                 }
             });
         }


### PR DESCRIPTION
# 概要
ショートカット実行時にManagerがストレージへのアクセス権限を取得していないと、デモページ起動時に 403 エラーが表示される。

# 発生するOSバージョン
Android 6.0 以上

# 修正点
- ショートカット実行時にストレージへのアクセス権限を取得する。
- Host プラグインのデモページの「開く」ボタン押下時、デモに必要なパーミッション（カメラ、マイク）を取得する。

# 動作確認準備
1. Host プラグインのデモページ設定画面で、デモページをインストール。
1. Host プラグインのデモページ設定画面で、デモページのショートカットを作成。
1. 端末標準のアプリ設定で、DeviceConnectManagerの「ストレージ」「カメラ」「マイク」の３つの権限をOFF。
1. DeviceConnectManagerのWebサーバーをOFFにする。
1. DeviceConnectManager（本体）をOFFにする。
1. Managerの設定画面を『ホームボタン』で閉じる。（以下の手順の途中でManagerの設定画面が出てこないことの確認に必要）

# 動作確認手順
1. ホーム画面上のショートカット「カメラ」を押下し、デモページ起動。
1. パーミッション要求ダイアログ（ストレージ）が表示されることを確認。
1. 上記について許可する。
1. Webサーバ起動の警告ダイアログが表示されるので、「はい」を選択。
1. ブラウザが起動することを確認。
1. DeviceConnnectManagerを起動するかどうかの確認ダイアログが表示されるので、「起動」を選択する。
1. 5秒前後、待機する。
1. Host サービスが見つからなかった場合、エラーが表示される。エラーが出なくなるまで「リトライ」を選択。（Manager起動後、すぐHostサービスが返された場合は出ない）
1. パーミッション要求ダイアログ（カメラ、マイク）が表示されることを確認。
1. 上記の２つについて許可する。
1. ブラウザの画面に戻ることを確認。
1. カメラのプレビューが表示されることを確認。