### PR TITLE
libstreamingのabiFiltersにx86_64を追加

### DIFF
--- a/dConnectSDK/dConnectLibStreaming/libstreaming/build.gradle
+++ b/dConnectSDK/dConnectLibStreaming/libstreaming/build.gradle
@@ -10,7 +10,7 @@ android {
         ndk {
             // Specifies the ABI configurations of your native
             // libraries Gradle should build and package with your APK.
-            abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86'
+            abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86','x86_64'
         }
     }
 


### PR DESCRIPTION
## 更新内容
* GooglePlayで64bit対応の警告が表示されるため、libstreamingのabiFiltersにx86_64を追加