### PR TITLE
LiveStreamingのbitrateの単位をMediaStreamRecording同一化

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/util/LiveStreamingClient.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/util/LiveStreamingClient.java
@@ -55,7 +55,7 @@ public class LiveStreamingClient implements MediaStreamer.OnEventListener {
                 videoQuality.setVideoHeight(height);
             }
             if (bitrate != null) {
-                videoQuality.setBitRate(bitrate);
+                videoQuality.setBitRate(bitrate * 1024);
             }
             if (frameRate != null) {
                 videoQuality.setFrameRate(frameRate);


### PR DESCRIPTION
## 修正内容
* LiveStreamingのbitrateの単位をMediaStreamRecordingとあわせた
   * bps→Kbps