### PR TITLE
HostのCameraの排他制御

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/camera/CameraWrapper.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/camera/CameraWrapper.java
@@ -848,6 +848,8 @@ public class CameraWrapper {
                 throw new IllegalArgumentException(e);
             } catch (CameraWrapperException e) {
                 throw new IllegalArgumentException(e);
+            } finally {
+                close();
             }
             notifyTorchOffEvent(listener, handler);
         }

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/camera/CameraWrapper.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/camera/CameraWrapper.java
@@ -804,7 +804,9 @@ public class CameraWrapper {
             }
             if (mIsRecording) {
                 requestBuilder.addTarget(mRecordingSurface);
-            } else {
+            }
+
+            if (!mIsPreview && !mIsRecording) {
                 requestBuilder.addTarget(mDummyPreviewReader.getSurface());
             }
             requestBuilder.set(CaptureRequest.FLASH_MODE, CameraMetadata.FLASH_MODE_TORCH);

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/camera/CameraWrapper.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/camera/CameraWrapper.java
@@ -99,11 +99,11 @@ public class CameraWrapper {
 
     private CameraCaptureSession mCaptureSession;
 
-    private static volatile boolean mIsTakingStillImage;
+    private boolean mIsTakingStillImage;
 
-    private static volatile boolean mIsPreview;
+    private boolean mIsPreview;
 
-    private static volatile boolean mIsRecording;
+    private boolean mIsRecording;
 
     private Surface mStillImageSurface;
 

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/camera/CameraWrapper.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/camera/CameraWrapper.java
@@ -99,11 +99,11 @@ public class CameraWrapper {
 
     private CameraCaptureSession mCaptureSession;
 
-    private boolean mIsTakingStillImage;
+    private static volatile boolean mIsTakingStillImage;
 
-    private boolean mIsPreview;
+    private static volatile boolean mIsPreview;
 
-    private boolean mIsRecording;
+    private static volatile boolean mIsRecording;
 
     private Surface mStillImageSurface;
 

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/camera/CameraWrapper.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/camera/CameraWrapper.java
@@ -551,6 +551,9 @@ public class CameraWrapper {
         close();
         if (mIsPreview) {
             startPreview(mPreviewSurface, true);
+        } else if (mIsTouchOn) {
+            mIsTouchOn = false;
+            turnOnTorch();
         }
         notifyCameraEvent(CameraEvent.STOPPED_VIDEO_RECORDING);
     }
@@ -623,17 +626,21 @@ public class CameraWrapper {
             }
             resumeRepeatingRequest();
             throw new CameraWrapperException(e);
+        } finally {
+            mIsTakingStillImage = false;
         }
     }
 
     private void resumeRepeatingRequest() {
-        mIsTakingStillImage = false;
 
         try {
             if (mIsRecording) {
                 startRecording(mRecordingSurface, true);
             } else if (mIsPreview) {
                 startPreview(mPreviewSurface, true);
+            } else if (mIsTouchOn) {
+                mIsTouchOn = false;
+                turnOnTorch();
             } else {
                 close();
             }
@@ -794,6 +801,9 @@ public class CameraWrapper {
                 if (mTargetSurface != null) {
                     requestBuilder.addTarget(mTargetSurface);
                 }
+            }
+            if (mIsRecording) {
+                requestBuilder.addTarget(mRecordingSurface);
             } else {
                 requestBuilder.addTarget(mDummyPreviewReader.getSurface());
             }
@@ -849,7 +859,7 @@ public class CameraWrapper {
             } catch (CameraWrapperException e) {
                 throw new IllegalArgumentException(e);
             } finally {
-                close();
+                resumeRepeatingRequest();
             }
             notifyTorchOffEvent(listener, handler);
         }

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/profile/HostLightProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/profile/HostLightProfile.java
@@ -89,12 +89,6 @@ public class HostLightProfile extends LightProfile {
                     new PermissionUtility.PermissionRequestCallback() {
                         @Override
                         public void onSuccess() {
-                            if (!(isCameraAvailable())) {
-                                MessageUtils.setIllegalDeviceStateError(response, "Camera device is already running.");
-                                sendResponse(response);
-                                return;
-                            }
-
                             Bundle lightParam = new Bundle();
                             setName(lightParam, HOST_DEFAULT_LIGHT_NAME);
                             setConfig(lightParam, "");
@@ -144,12 +138,6 @@ public class HostLightProfile extends LightProfile {
                     new PermissionUtility.PermissionRequestCallback() {
                         @Override
                         public void onSuccess() {
-                            if (!(isCameraAvailable())) {
-                                MessageUtils.setIllegalDeviceStateError(response, "Camera device is already running.");
-                                sendResponse(response);
-                                return;
-                            }
-
                             if (flashing != null) {
                                 flashing(HOST_LIGHT_ID, flashing);
                                 setResult(response, DConnectMessage.RESULT_OK);
@@ -213,12 +201,6 @@ public class HostLightProfile extends LightProfile {
                     new PermissionUtility.PermissionRequestCallback() {
                         @Override
                         public void onSuccess() {
-                            if (!(isCameraAvailable())) {
-                                MessageUtils.setIllegalDeviceStateError(response, "Camera device is already running.");
-                                sendResponse(response);
-                                return;
-                            }
-
                             mPhotoRec.turnOffFlashLight(new HostDevicePhotoRecorder.TurnOffFlashLightListener() {
                                 @Override
                                 public void onRequested() {
@@ -292,18 +274,6 @@ public class HostLightProfile extends LightProfile {
         HandlerThread thread = new HandlerThread(name);
         thread.start();
         return new Handler(thread.getLooper());
-    }
-
-    /**
-     * カメラが使用可能どうかをチェックする.
-     *
-     * @return 使用可能の場合は true, そうでない場合は false.
-     */
-    private boolean isCameraAvailable() {
-        if (((HostMediaRecorder) mPhotoRec).getState() != HostMediaRecorder.RecorderState.INACTTIVE) {
-            return false;
-        }
-        return true;
     }
 
     /**

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/profile/HostLiveStreamingProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/profile/HostLiveStreamingProfile.java
@@ -48,6 +48,8 @@ public class HostLiveStreamingProfile extends DConnectProfile implements LiveStr
     private static final String VIDEO_URI_FALSE = "false";
     private static final String VIDEO_URI_CAMERA_FRONT = "camera-front";
     private static final String VIDEO_URI_CAMERA_BACK = "camera-back";
+    private static final String VIDEO_URI_CAMERA_0 = "camera_0";
+    private static final String VIDEO_URI_CAMERA_1 = "camera_1";
     private static final String AUDIO_URI_TRUE = "true";
     private static final String AUDIO_URI_FALSE = "false";
     private static final int CAMERA_TYPE_FRONT = 0;
@@ -108,6 +110,8 @@ public class HostLiveStreamingProfile extends DConnectProfile implements LiveStr
                             case VIDEO_URI_FALSE:
                             case VIDEO_URI_CAMERA_FRONT:
                             case VIDEO_URI_CAMERA_BACK:
+                            case VIDEO_URI_CAMERA_0:
+                            case VIDEO_URI_CAMERA_1:
                                 break;
                             default:
                                 MessageUtils.setInvalidRequestParameterError(response, "video parameter illegal");
@@ -373,15 +377,17 @@ public class HostLiveStreamingProfile extends DConnectProfile implements LiveStr
                 }
                 break;
             }
-            case VIDEO_URI_CAMERA_FRONT: {
-                HostMediaRecorder hostMediaRecorder = getRecorder(CAMERA_TYPE_FRONT);
+            case VIDEO_URI_CAMERA_FRONT:
+            case VIDEO_URI_CAMERA_1: {
+                HostMediaRecorder hostMediaRecorder = mHostMediaRecorderManager.getRecorder(VIDEO_URI_CAMERA_1);
                 if (hostMediaRecorder instanceof HostDeviceLiveStreamRecorder) {
                     return (HostDeviceLiveStreamRecorder) hostMediaRecorder;
                 }
                 break;
             }
-            case VIDEO_URI_CAMERA_BACK: {
-                HostMediaRecorder hostMediaRecorder = getRecorder(CAMERA_TYPE_BACK);
+            case VIDEO_URI_CAMERA_BACK:
+            case VIDEO_URI_CAMERA_0: {
+                HostMediaRecorder hostMediaRecorder = mHostMediaRecorderManager.getRecorder(VIDEO_URI_CAMERA_0);
                 if (hostMediaRecorder instanceof HostDeviceLiveStreamRecorder) {
                     return (HostDeviceLiveStreamRecorder) hostMediaRecorder;
                 }
@@ -390,31 +396,6 @@ public class HostLiveStreamingProfile extends DConnectProfile implements LiveStr
         }
         Log.e(TAG, "getHostDeviceLiveStreamRecorder() recorder not found");
         throw new RuntimeException("recorder not found");
-    }
-
-
-    private HostMediaRecorder getRecorder(int type) {
-        if (DEBUG) {
-            Log.d(TAG, "getRecorder()");
-            Log.d(TAG, "type" + type);
-        }
-        for(HostMediaRecorder hostMediaRecorder : mHostMediaRecorderManager.getRecorders()) {
-            if (DEBUG) {
-                Log.d(TAG, "name : " + hostMediaRecorder.getName());
-            }
-            if (hostMediaRecorder.getName().matches("^Camera [0-9] \\((Front|Back)\\)")) {
-                if (type == CAMERA_TYPE_FRONT) {
-                    if (hostMediaRecorder.getName().contains("Front")) {
-                        return hostMediaRecorder;
-                    }
-                } else if (type == CAMERA_TYPE_BACK) {
-                    if (hostMediaRecorder.getName().contains("Back")) {
-                        return hostMediaRecorder;
-                    }
-                }
-            }
-        }
-        return null;
     }
 
     @Override

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/profile/HostLiveStreamingProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/profile/HostLiveStreamingProfile.java
@@ -357,21 +357,19 @@ public class HostLiveStreamingProfile extends DConnectProfile implements LiveStr
         });
     }
 
-    private HostDeviceLiveStreamRecorder getHostDeviceLiveStreamRecorder() {
+    private HostDeviceLiveStreamRecorder getHostDeviceLiveStreamRecorder()  {
         if (DEBUG) {
             Log.d(TAG, "getHostDeviceLiveStreamRecorder()");
             Log.d(TAG, "mVideoURI : " + mVideoURI);
         }
         switch (mVideoURI) {
-            case VIDEO_URI_TRUE: {
-                HostMediaRecorder hostMediaRecorder = mHostMediaRecorderManager.getRecorder(null);
-                if (hostMediaRecorder instanceof HostDeviceLiveStreamRecorder) {
-                    return (HostDeviceLiveStreamRecorder) hostMediaRecorder;
-                }
-                break;
-            }
+            case VIDEO_URI_TRUE:
             case VIDEO_URI_FALSE: {
                 HostMediaRecorder hostMediaRecorder = mHostMediaRecorderManager.getRecorder(null);
+                if (mHostMediaRecorderManager.usingStreamingRecorder()) {
+                    throw new RuntimeException("Another target in using.");
+                }
+
                 if (hostMediaRecorder instanceof HostDeviceLiveStreamRecorder) {
                     return (HostDeviceLiveStreamRecorder) hostMediaRecorder;
                 }
@@ -380,6 +378,9 @@ public class HostLiveStreamingProfile extends DConnectProfile implements LiveStr
             case VIDEO_URI_CAMERA_FRONT:
             case VIDEO_URI_CAMERA_1: {
                 HostMediaRecorder hostMediaRecorder = mHostMediaRecorderManager.getRecorder(VIDEO_URI_CAMERA_1);
+                if (mHostMediaRecorderManager.usingStreamingRecorder()) {
+                    throw new RuntimeException("Another target in using.");
+                }
                 if (hostMediaRecorder instanceof HostDeviceLiveStreamRecorder) {
                     return (HostDeviceLiveStreamRecorder) hostMediaRecorder;
                 }
@@ -388,6 +389,10 @@ public class HostLiveStreamingProfile extends DConnectProfile implements LiveStr
             case VIDEO_URI_CAMERA_BACK:
             case VIDEO_URI_CAMERA_0: {
                 HostMediaRecorder hostMediaRecorder = mHostMediaRecorderManager.getRecorder(VIDEO_URI_CAMERA_0);
+                if (mHostMediaRecorderManager.usingPreviewOrStreamingRecorder(hostMediaRecorder.getId())) {
+                    throw new RuntimeException("Another target in using.");
+                }
+
                 if (hostMediaRecorder instanceof HostDeviceLiveStreamRecorder) {
                     return (HostDeviceLiveStreamRecorder) hostMediaRecorder;
                 }

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/profile/HostMediaStreamingRecordingProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/profile/HostMediaStreamingRecordingProfile.java
@@ -61,6 +61,10 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
     private final FileManager mFileManager;
 
     /**
+     * 現在起動中のレコーダーID.
+     */
+    private static volatile String mCurrentRecorderId;
+    /**
      * KeyEventProfileActivity からの KeyEvent を中継する Broadcast Receiver.
      */
     private BroadcastReceiver mAudioEventBR = new BroadcastReceiver() {
@@ -431,6 +435,11 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
                 MessageUtils.setInvalidRequestParameterError(response, "target is invalid.");
                 return true;
             }
+            if (mCurrentRecorderId != null && !mCurrentRecorderId.equals(recorder.getId())) {
+                MessageUtils.setInvalidRequestParameterError(response, "Another target in using.");
+                return true;
+            }
+            mCurrentRecorderId = recorder.getId();
 
             if (!(recorder instanceof HostDevicePhotoRecorder)) {
                 MessageUtils.setNotSupportAttributeError(response,
@@ -463,12 +472,14 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
                                 intent.putExtra(MediaStreamRecordingProfile.PARAM_PHOTO, photo);
                                 sendEvent(intent, evt.getAccessToken());
                             }
+                            mCurrentRecorderId = null;
                         }
 
                         @Override
                         public void onFailedTakePhoto(final String errorMessage) {
                             MessageUtils.setUnknownError(response, errorMessage);
                             sendResponse(response);
+                            mCurrentRecorderId = null;
                         }
                     });
                 }
@@ -477,6 +488,7 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
                 public void onDisallowed() {
                     MessageUtils.setUnknownError(response, "Permission for camera is not granted.");
                     sendResponse(response);
+                    mCurrentRecorderId = null;
                 }
             });
 
@@ -501,7 +513,11 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
                 MessageUtils.setInvalidRequestParameterError(response, "target is invalid.");
                 return true;
             }
-
+            if (mCurrentRecorderId != null && !mCurrentRecorderId.equals(recorder.getId())) {
+                MessageUtils.setInvalidRequestParameterError(response, "Another target in using.");
+                return true;
+            }
+            mCurrentRecorderId = recorder.getId();
             recorder.requestPermission(new HostMediaRecorder.PermissionCallback() {
                 @Override
                 public void onAllowed() {
@@ -559,6 +575,7 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
                 MessageUtils.setInvalidRequestParameterError(response, "target is invalid.");
                 return true;
             }
+            mCurrentRecorderId = null;
 
             recorder.requestPermission(new HostMediaRecorder.PermissionCallback() {
                 @Override
@@ -678,6 +695,11 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
                 MessageUtils.setInvalidRequestParameterError(response, "target is invalid.");
                 return true;
             }
+            if (mCurrentRecorderId != null && !mCurrentRecorderId.equals(recorder.getId())) {
+                MessageUtils.setInvalidRequestParameterError(response, "Another target in using.");
+                return true;
+            }
+            mCurrentRecorderId = recorder.getId();
 
             if (!(recorder instanceof HostDeviceStreamRecorder)) {
                 MessageUtils.setNotSupportAttributeError(response,
@@ -744,7 +766,7 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
                 MessageUtils.setInvalidRequestParameterError(response, "target is invalid.");
                 return true;
             }
-
+            mCurrentRecorderId = null;
             if (!(recorder instanceof HostDeviceStreamRecorder)) {
                 MessageUtils.setNotSupportAttributeError(response,
                         "target does not support stream recording.");
@@ -907,7 +929,7 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
     public HostMediaStreamingRecordingProfile(final HostMediaRecorderManager mgr, final FileManager fileMgr) {
         mRecorderMgr = mgr;
         mFileManager = fileMgr;
-
+        mCurrentRecorderId = null;
         addApi(mGetMediaRecorderApi);
         addApi(mGetOptionsApi);
         addApi(mPutOptionsApi);

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/profile/HostMediaStreamingRecordingProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/profile/HostMediaStreamingRecordingProfile.java
@@ -695,7 +695,7 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
                 return true;
             }
 
-            if (recorder.getState() != HostMediaRecorder.RecorderState.INACTTIVE) {
+            if (recorder.getState() != HostMediaRecorder.RecorderState.INACTIVE) {
                 MessageUtils.setIllegalDeviceStateError(response,
                         recorder.getName() + " is already running.");
                 return true;
@@ -760,7 +760,7 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
                 return true;
             }
 
-            if (recorder.getState() == HostMediaRecorder.RecorderState.INACTTIVE) {
+            if (recorder.getState() == HostMediaRecorder.RecorderState.INACTIVE) {
                 MessageUtils.setIllegalDeviceStateError(response, "recorder is stopped already.");
                 return true;
             }

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/profile/HostMediaStreamingRecordingProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/profile/HostMediaStreamingRecordingProfile.java
@@ -61,10 +61,6 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
     private final FileManager mFileManager;
 
     /**
-     * 現在起動中のレコーダーID.
-     */
-    private static volatile String mCurrentRecorderId;
-    /**
      * KeyEventProfileActivity からの KeyEvent を中継する Broadcast Receiver.
      */
     private BroadcastReceiver mAudioEventBR = new BroadcastReceiver() {
@@ -435,11 +431,10 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
                 MessageUtils.setInvalidRequestParameterError(response, "target is invalid.");
                 return true;
             }
-            if (mCurrentRecorderId != null && !mCurrentRecorderId.equals(recorder.getId())) {
+            if (mRecorderMgr.usingPreviewOrStreamingRecorder(recorder.getId())) {
                 MessageUtils.setInvalidRequestParameterError(response, "Another target in using.");
                 return true;
             }
-            mCurrentRecorderId = recorder.getId();
 
             if (!(recorder instanceof HostDevicePhotoRecorder)) {
                 MessageUtils.setNotSupportAttributeError(response,
@@ -472,14 +467,12 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
                                 intent.putExtra(MediaStreamRecordingProfile.PARAM_PHOTO, photo);
                                 sendEvent(intent, evt.getAccessToken());
                             }
-                            mCurrentRecorderId = null;
                         }
 
                         @Override
                         public void onFailedTakePhoto(final String errorMessage) {
                             MessageUtils.setUnknownError(response, errorMessage);
                             sendResponse(response);
-                            mCurrentRecorderId = null;
                         }
                     });
                 }
@@ -488,7 +481,6 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
                 public void onDisallowed() {
                     MessageUtils.setUnknownError(response, "Permission for camera is not granted.");
                     sendResponse(response);
-                    mCurrentRecorderId = null;
                 }
             });
 
@@ -513,11 +505,10 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
                 MessageUtils.setInvalidRequestParameterError(response, "target is invalid.");
                 return true;
             }
-            if (mCurrentRecorderId != null && !mCurrentRecorderId.equals(recorder.getId())) {
+            if (mRecorderMgr.usingPreviewOrStreamingRecorder(recorder.getId())) {
                 MessageUtils.setInvalidRequestParameterError(response, "Another target in using.");
                 return true;
             }
-            mCurrentRecorderId = recorder.getId();
             recorder.requestPermission(new HostMediaRecorder.PermissionCallback() {
                 @Override
                 public void onAllowed() {
@@ -575,8 +566,6 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
                 MessageUtils.setInvalidRequestParameterError(response, "target is invalid.");
                 return true;
             }
-            mCurrentRecorderId = null;
-
             recorder.requestPermission(new HostMediaRecorder.PermissionCallback() {
                 @Override
                 public void onAllowed() {
@@ -695,11 +684,10 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
                 MessageUtils.setInvalidRequestParameterError(response, "target is invalid.");
                 return true;
             }
-            if (mCurrentRecorderId != null && !mCurrentRecorderId.equals(recorder.getId())) {
+            if (mRecorderMgr.usingPreviewOrStreamingRecorder(recorder.getId())) {
                 MessageUtils.setInvalidRequestParameterError(response, "Another target in using.");
                 return true;
             }
-            mCurrentRecorderId = recorder.getId();
 
             if (!(recorder instanceof HostDeviceStreamRecorder)) {
                 MessageUtils.setNotSupportAttributeError(response,
@@ -766,7 +754,6 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
                 MessageUtils.setInvalidRequestParameterError(response, "target is invalid.");
                 return true;
             }
-            mCurrentRecorderId = null;
             if (!(recorder instanceof HostDeviceStreamRecorder)) {
                 MessageUtils.setNotSupportAttributeError(response,
                         "target does not support stream recording.");
@@ -929,7 +916,6 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
     public HostMediaStreamingRecordingProfile(final HostMediaRecorderManager mgr, final FileManager fileMgr) {
         mRecorderMgr = mgr;
         mFileManager = fileMgr;
-        mCurrentRecorderId = null;
         addApi(mGetMediaRecorderApi);
         addApi(mGetOptionsApi);
         addApi(mPutOptionsApi);

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/profile/HostMediaStreamingRecordingProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/profile/HostMediaStreamingRecordingProfile.java
@@ -218,7 +218,8 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
                 return;
             }
 
-            if (recorder.getState() != HostMediaRecorder.RecorderState.INACTTIVE) {
+            if (recorder.getState() != HostMediaRecorder.RecorderState.INACTIVE
+                && recorder.getState() != HostMediaRecorder.RecorderState.PREVIEW) {
                 MessageUtils.setInvalidRequestParameterError(response, "settings of active target cannot be changed.");
                 return;
             }

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/profile/HostMediaStreamingRecordingProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/profile/HostMediaStreamingRecordingProfile.java
@@ -696,7 +696,8 @@ public class HostMediaStreamingRecordingProfile extends MediaStreamRecordingProf
                 return true;
             }
 
-            if (recorder.getState() != HostMediaRecorder.RecorderState.INACTIVE) {
+            if (recorder.getState() != HostMediaRecorder.RecorderState.INACTIVE
+                && recorder.getState() != HostMediaRecorder.RecorderState.PREVIEW) {
                 MessageUtils.setIllegalDeviceStateError(response,
                         recorder.getName() + " is already running.");
                 return true;

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/AbstractPreviewServerProvider.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/AbstractPreviewServerProvider.java
@@ -52,6 +52,7 @@ public abstract class AbstractPreviewServerProvider implements PreviewServerProv
      */
     private HostMediaRecorder mRecorder;
 
+    private boolean mIsShownNotification;
     /**
      * コンストラクタ.
      * @param context コンテキスト
@@ -60,6 +61,7 @@ public abstract class AbstractPreviewServerProvider implements PreviewServerProv
         mContext = context;
         mRecorder = recorder;
         mNotificationId = notificationId;
+        mIsShownNotification = false;
     }
 
     // PreviewServerProvider
@@ -118,6 +120,7 @@ public abstract class AbstractPreviewServerProvider implements PreviewServerProv
                 // TODO タイムアウト処理
             } else {
                 sendNotification(mRecorder.getId(), mRecorder.getName());
+                mIsShownNotification = true;
             }
         } catch (InterruptedException e) {
             // ignore.
@@ -171,6 +174,7 @@ public abstract class AbstractPreviewServerProvider implements PreviewServerProv
                 .getSystemService(Service.NOTIFICATION_SERVICE);
         if (manager != null) {
             manager.cancel(id, getNotificationId());
+            mIsShownNotification = false;
         }
     }
 
@@ -251,5 +255,10 @@ public abstract class AbstractPreviewServerProvider implements PreviewServerProv
         intent.setAction(DELETE_PREVIEW_ACTION);
         intent.putExtra(EXTRA_CAMERA_ID, id);
         return PendingIntent.getBroadcast(mContext, getNotificationId(), intent, 0);
+    }
+
+    @Override
+    public boolean isShownCameraNotification() {
+        return mIsShownNotification;
     }
 }

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostMediaRecorder.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostMediaRecorder.java
@@ -287,7 +287,7 @@ public interface HostMediaRecorder {
         /**
          * 動作していない.
          */
-        INACTTIVE,
+        INACTIVE,
 
         /**
          * 録画が一時停止中の状態.

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostMediaRecorder.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostMediaRecorder.java
@@ -300,6 +300,11 @@ public interface HostMediaRecorder {
         RECORDING,
 
         /**
+         * プレビューが表示されている状態.
+         */
+        PREVIEW,
+
+        /**
          * エラーで停止している状態.
          */
         ERROR

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostMediaRecorderManager.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostMediaRecorderManager.java
@@ -12,10 +12,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
-import android.graphics.Camera;
 import android.os.Build;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.WindowManager;
 
 import org.deviceconnect.android.deviceplugin.host.camera.CameraWrapper;
@@ -359,7 +357,7 @@ public class HostMediaRecorderManager {
             case RECORDING:
                 MediaStreamRecordingProfile.setStatus(record, MediaStreamRecordingProfileConstants.RecordingState.RECORDING);
                 break;
-            case INACTTIVE:
+            case INACTIVE:
                 MediaStreamRecordingProfile.setStatus(record, MediaStreamRecordingProfileConstants.RecordingState.STOP);
                 break;
             case ERROR:

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostMediaRecorderManager.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostMediaRecorderManager.java
@@ -12,8 +12,10 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
+import android.graphics.Camera;
 import android.os.Build;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.WindowManager;
 
 import org.deviceconnect.android.deviceplugin.host.camera.CameraWrapper;
@@ -235,6 +237,52 @@ public class HostMediaRecorderManager {
         return null;
     }
 
+    /**
+     * 指定された ID 以外のレコーダが.
+     *
+     * <p>
+     * id に null が指定された場合には、デフォルトに設定されているレコーダを返却します。
+     * </p>
+     *
+     * @param id レコーダの識別子
+     * @return 他のレコーダーが使用中であるかどうか true:使用中 false:使用されていない
+     */
+    public boolean usingPreviewOrStreamingRecorder(String id) {
+        if (mRecorders.size() == 0) {
+            return false;
+        }
+        if (id == null) {
+            if (mDefaultPhotoRecorder != null) {
+                id = mDefaultPhotoRecorder.getId();
+            } else {
+                id = mRecorders.get(0).getId();
+            }
+        }
+        for (HostMediaRecorder recorder : mRecorders) {
+            if (!id.equals(recorder.getId())
+                    && (recorder.getState() == HostMediaRecorder.RecorderState.PREVIEW
+                        || recorder.getState() == HostMediaRecorder.RecorderState.RECORDING)) {
+                return true;
+            } else if (recorder instanceof HostDeviceLiveStreamRecorder
+                    && ((HostDeviceLiveStreamRecorder) recorder).isStreaming()) {
+                return true;
+            }
+        }
+        return false;
+    }
+    /**
+     * レコーダーが使用中である、あるいはストリーミングが開始している場合はtrueを返す.
+     *
+     * @return true:使用中 false:使用されていない
+     */
+    public boolean usingStreamingRecorder() {
+        for (HostMediaRecorder recorder : mRecorders) {
+            return recorder.getState() == HostMediaRecorder.RecorderState.PREVIEW
+                    || recorder.getState() == HostMediaRecorder.RecorderState.RECORDING
+                    || ((HostDeviceLiveStreamRecorder) recorder).isStreaming();
+        }
+        return false;
+    }
     /**
      * 指定された ID に対応する静止画用のレコーダを取得します.
      *

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/PreviewServerProvider.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/PreviewServerProvider.java
@@ -73,4 +73,10 @@ public interface PreviewServerProvider {
      * 設定が変更されたことを通知します.
      */
     void onConfigChange();
+
+    /**
+     * Previewの状態を表すNotificationが表示されているかどうかのフラグを返します.
+     * return true:表示されている false:表示されていない
+     */
+    boolean isShownCameraNotification();
 }

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/audio/HostAudioRecorder.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/audio/HostAudioRecorder.java
@@ -88,7 +88,7 @@ public class HostAudioRecorder implements HostMediaRecorder, HostDeviceStreamRec
 
     public HostAudioRecorder(final Context context) {
         mContext = context;
-        mState = RecorderState.INACTTIVE;
+        mState = RecorderState.INACTIVE;
     }
 
     @Override
@@ -290,10 +290,10 @@ public class HostAudioRecorder implements HostMediaRecorder, HostDeviceStreamRec
 
     @Override
     public synchronized void stopRecording(final StoppingListener listener) {
-        if (getState() == RecorderState.INACTTIVE) {
+        if (getState() == RecorderState.INACTIVE) {
             listener.onFailed(this, "MediaRecorder is not running.");
         } else {
-            mState = RecorderState.INACTTIVE;
+            mState = RecorderState.INACTIVE;
             if (listener != null) {
                 if (mMediaRecorder != null) {
                     mMediaRecorder.stop();

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/camera/Camera2Recorder.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/camera/Camera2Recorder.java
@@ -252,6 +252,10 @@ public class Camera2Recorder implements HostMediaRecorder, HostDevicePhotoRecord
         if (mCameraWrapper.isRecording() || mCameraWrapper.isTakingStillImage()) {
             return RecorderState.RECORDING;
         }
+        // Preview用のNotificationが表示されている場合は、カメラをPreviewで占有しているものと判断する。
+        if (mCamera2PreviewServerProvider.isShownCameraNotification()) {
+            return RecorderState.PREVIEW;
+        }
         return RecorderState.INACTTIVE;
     }
 

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/camera/Camera2Recorder.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/camera/Camera2Recorder.java
@@ -256,7 +256,7 @@ public class Camera2Recorder implements HostMediaRecorder, HostDevicePhotoRecord
         if (mCamera2PreviewServerProvider.isShownCameraNotification()) {
             return RecorderState.PREVIEW;
         }
-        return RecorderState.INACTTIVE;
+        return RecorderState.INACTIVE;
     }
 
     @Override

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/screen/ScreenCastRecorder.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/screen/ScreenCastRecorder.java
@@ -82,7 +82,7 @@ public class ScreenCastRecorder implements HostMediaRecorder, HostDevicePhotoRec
     private int mPreviewBitRate = 1024 * 1024;
     private double mMaxFps = DEFAULT_MAX_FPS;
     private int mIFrameInterval = 2;
-    private RecorderState mState = RecorderState.INACTTIVE;
+    private RecorderState mState = RecorderState.INACTIVE;
 
     private final MediaSharing mMediaSharing = MediaSharing.getInstance();
 
@@ -420,7 +420,7 @@ public class ScreenCastRecorder implements HostMediaRecorder, HostDevicePhotoRec
 
             Bitmap bitmap = screenshot.get();
             if (bitmap == null) {
-                mState = RecorderState.INACTTIVE;
+                mState = RecorderState.INACTIVE;
                 listener.onFailedTakePhoto("Failed to take screenshot.");
                 return;
             }
@@ -433,14 +433,14 @@ public class ScreenCastRecorder implements HostMediaRecorder, HostDevicePhotoRec
             mFileMgr.saveFile(filename, media, true, new FileManager.SaveFileCallback() {
                 @Override
                 public void onSuccess(@NonNull final String uri) {
-                    mState = RecorderState.INACTTIVE;
+                    mState = RecorderState.INACTIVE;
                     registerPhoto(new File(mFileMgr.getBasePath(), filename));
                     listener.onTakePhoto(uri, null, MIME_TYPE_JPEG);
                 }
 
                 @Override
                 public void onFail(@NonNull final Throwable throwable) {
-                    mState = RecorderState.INACTTIVE;
+                    mState = RecorderState.INACTIVE;
                     listener.onFailedTakePhoto(throwable.getMessage());
                 }
             });


### PR DESCRIPTION
## 更新内容
* HostのFront/Backカメラを同時に使えないようにした。
* HostのMediaStreamRecordingのtargetに合わせて配信できるようにした。