### PR TITLE
rtmp-rtsp-stream-client-javaのバージョンを1.9.1にした

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/app/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/build.gradle
@@ -85,7 +85,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation "androidx.preference:preference:1.1.0"
-    implementation 'com.github.pedroSG94.rtmp-rtsp-stream-client-java:rtplibrary:1.6.7'
+    implementation 'com.github.pedroSG94.rtmp-rtsp-stream-client-java:rtplibrary:1.9.1'
     implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.4'
     implementation 'org.deviceconnect:libmedia:1.0.0'
     implementation 'org.deviceconnect:libsrt:1.0.0'


### PR DESCRIPTION
## 更新
* Pixel端末で映像が配信できない件の修正。