### PR TITLE
libmediaのMJPEGEncoderのstartの中でエラーが発生した場合に後始末処理が行われない

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/app/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     implementation "androidx.preference:preference:1.1.0"
     implementation 'com.github.pedroSG94.rtmp-rtsp-stream-client-java:rtplibrary:1.9.1'
     implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.6'
-    implementation 'org.deviceconnect:libmedia:1.1.0'
+    implementation 'org.deviceconnect:libmedia:1.1.1'
     implementation 'org.deviceconnect:libsrt:1.1.1'
     implementation 'org.deviceconnect:dconnect-demo-lib:1.0.1'
 }

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/AbstractPreviewServerProvider.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/AbstractPreviewServerProvider.java
@@ -116,12 +116,9 @@ public abstract class AbstractPreviewServerProvider implements PreviewServerProv
         }
 
         try {
-            if (!latch.await(10, TimeUnit.SECONDS)) {
-                // TODO タイムアウト処理
-            } else {
-                sendNotification(mRecorder.getId(), mRecorder.getName());
-                mIsShownNotification = true;
-            }
+            latch.await(10, TimeUnit.SECONDS);
+            sendNotification(mRecorder.getId(), mRecorder.getName());
+            mIsShownNotification = true;
         } catch (InterruptedException e) {
             // ignore.
         }

--- a/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostMediaRecorder.java
+++ b/dConnectDevicePlugin/dConnectDeviceHost/app/src/main/java/org/deviceconnect/android/deviceplugin/host/recorder/HostMediaRecorder.java
@@ -207,7 +207,7 @@ public interface HostMediaRecorder {
 
     /**
      * プレビュー配信サーバを起動します.
-     *
+     * サーバが起動できなかった場合には、空のリストを返却する。
      * @return 起動したプレビュー配信サーバのリスト
      */
     List<PreviewServer> startPreviews();

--- a/dConnectDevicePlugin/dConnectDeviceTheta/app/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceTheta/app/build.gradle
@@ -82,7 +82,7 @@ android {
 dependencies {
     implementation fileTree(include: '*.jar', dir: 'libs')
     implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.6'
-    implementation 'org.deviceconnect:libmedia:1.1.0'
+    implementation 'org.deviceconnect:libmedia:1.1.1'
     implementation 'com.squareup.okhttp3:okhttp:3.10.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'com.burgstaller:okhttp-digest:1.16'

--- a/dConnectDevicePlugin/dConnectDeviceUVC/app/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/app/build.gradle
@@ -78,6 +78,6 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation 'com.github.pedroSG94.rtmp-rtsp-stream-client-java:rtplibrary:1.9.1'
     implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.6'
-    implementation 'org.deviceconnect:libmedia:1.1.1.3'
+    implementation 'org.deviceconnect:libmedia:1.1.1.4'
     implementation project(':libuvccamera')
 }

--- a/dConnectDevicePlugin/dConnectDeviceUVC/app/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/app/build.gradle
@@ -64,7 +64,7 @@ android {
     repositories {
         maven {
             name = "DeviceConnect-Android"
-            url = uri("https://maven.pkg.github.com/TakayukiHoshi1984/DeviceConnect-Android")
+            url = uri("https://maven.pkg.github.com/DeviceConnect/DeviceConnect-Android")
 
             credentials {
                 username = System.getenv("GPR_USER") ?: githubProperties['gpr.usr']
@@ -78,6 +78,6 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation 'com.github.pedroSG94.rtmp-rtsp-stream-client-java:rtplibrary:1.9.1'
     implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.6'
-    implementation 'org.deviceconnect:libmedia:1.1.1.4'
+    implementation 'org.deviceconnect:libmedia:1.1.1'
     implementation project(':libuvccamera')
 }

--- a/dConnectDevicePlugin/dConnectDeviceUVC/app/build.gradle
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/app/build.gradle
@@ -64,7 +64,7 @@ android {
     repositories {
         maven {
             name = "DeviceConnect-Android"
-            url = uri("https://maven.pkg.github.com/DeviceConnect/DeviceConnect-Android")
+            url = uri("https://maven.pkg.github.com/TakayukiHoshi1984/DeviceConnect-Android")
 
             credentials {
                 username = System.getenv("GPR_USER") ?: githubProperties['gpr.usr']
@@ -78,6 +78,6 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation 'com.github.pedroSG94.rtmp-rtsp-stream-client-java:rtplibrary:1.9.1'
     implementation 'org.deviceconnect:dconnect-device-plugin-sdk:2.8.6'
-    implementation 'org.deviceconnect:libmedia:1.1.0'
+    implementation 'org.deviceconnect:libmedia:1.1.1.3'
     implementation project(':libuvccamera')
 }

--- a/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/UVCDeviceService.java
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/UVCDeviceService.java
@@ -130,7 +130,7 @@ public class UVCDeviceService extends DConnectMessageService {
     @Override
     protected void onKeyStoreUpdated(final KeyStore keyStore, final Certificate cert, final Certificate rootCert) {
         try {
-            if (keyStore == null) {
+            if (keyStore == null || getPluginContext() == null) {
                 return;
             }
             mSSLContext = createSSLContext(keyStore, "0000");

--- a/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/profile/UVCMediaStreamRecordingProfile.java
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/profile/UVCMediaStreamRecordingProfile.java
@@ -300,19 +300,24 @@ public class UVCMediaStreamRecordingProfile extends MediaStreamRecordingProfile 
         }
         String defaultUri = null;
         List<Bundle> streams = new ArrayList<>();
-        for (PreviewServer server : getUVCRecorder().startPreview()) {
-            // Motion-JPEG をデフォルトの値として使用します
-            if (defaultUri == null && "video/x-mjpeg".equals(server.getMimeType())) {
-                defaultUri = server.getUrl();
-            }
+        List<PreviewServer> servers = getUVCRecorder().startPreview();
+        if (servers.isEmpty()) {
+            MessageUtils.setIllegalServerStateError(response, "Failed to start web server.");
+        } else {
+            for (PreviewServer server : servers) {
+                // Motion-JPEG をデフォルトの値として使用します
+                if (defaultUri == null && "video/x-mjpeg".equals(server.getMimeType())) {
+                    defaultUri = server.getUrl();
+                }
 
-            Bundle stream = new Bundle();
-            stream.putString("mimeType", server.getMimeType());
-            stream.putString("uri", server.getUrl());
-            streams.add(stream);
+                Bundle stream = new Bundle();
+                stream.putString("mimeType", server.getMimeType());
+                stream.putString("uri", server.getUrl());
+                streams.add(stream);
+            }
+            setResult(response, DConnectMessage.RESULT_OK);
+            setUri(response, defaultUri != null ? defaultUri : "");
+            response.putExtra("streams", streams.toArray(new Bundle[streams.size()]));
         }
-        setResult(response, DConnectMessage.RESULT_OK);
-        setUri(response, defaultUri != null ? defaultUri : "");
-        response.putExtra("streams", streams.toArray(new Bundle[streams.size()]));
     }
 }

--- a/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/recorder/MediaRecorder.java
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/recorder/MediaRecorder.java
@@ -158,7 +158,7 @@ public interface MediaRecorder {
 
     /**
      * プレビューを開始します.
-     *
+     * サーバが起動できなかった場合には、空のリストを返却する。
      * @return 起動したプレビュー配信サーバのリスト
      */
     List<PreviewServer> startPreview();

--- a/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/recorder/UVCRecorder.java
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/recorder/UVCRecorder.java
@@ -168,9 +168,7 @@ public class UVCRecorder implements MediaRecorder {
             });
         }
         try {
-            if (!lock.await(5, TimeUnit.SECONDS)) {
-                // TODO タイムアウト処理
-            }
+            lock.await(5, TimeUnit.SECONDS);
         } catch (Exception e) {
             // ignore.
         }

--- a/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/recorder/UVCRecorder.java
+++ b/dConnectDevicePlugin/dConnectDeviceUVC/app/src/main/java/org/deviceconnect/android/deviceplugin/uvc/recorder/UVCRecorder.java
@@ -158,6 +158,7 @@ public class UVCRecorder implements MediaRecorder {
                 @Override
                 public void onStart(@NonNull String uri) {
                     results.add(server);
+                    lock.countDown();
                 }
 
                 @Override

--- a/dConnectSDK/dConnectLibStreaming/libmedia/build.gradle
+++ b/dConnectSDK/dConnectLibStreaming/libmedia/build.gradle
@@ -6,11 +6,11 @@ if (githubPropertiesFile.exists()) {
     githubProperties.load(new FileInputStream(githubPropertiesFile))
 }
 def getVersionName = { ->
-    return "1.1.0" // Replace with version Name
+    return "1.1.1.3"
 }
 
 def getArtificatId = { ->
-    return "libmedia" // Replace with library name ID
+    return "libmedia"
 }
 android {
     compileSdkVersion 29
@@ -115,7 +115,7 @@ publishing {
             /** Configure path of your package repository on Github
              *  Replace GITHUB_USERID with your/organisation Github userID and REPOSITORY with the repository name on GitHub
              */
-            url = uri("https://maven.pkg.github.com/DeviceConnect/DeviceConnect-Android")
+            url = uri("https://maven.pkg.github.com/TakayukiHoshi1984/DeviceConnect-Android")
 
             credentials {
                 /**Create github.properties in root project folder file with gpr.usr=GITHUB_USER_ID  & gpr.key=PERSONAL_ACCESS_TOKEN**/

--- a/dConnectSDK/dConnectLibStreaming/libmedia/build.gradle
+++ b/dConnectSDK/dConnectLibStreaming/libmedia/build.gradle
@@ -6,7 +6,7 @@ if (githubPropertiesFile.exists()) {
     githubProperties.load(new FileInputStream(githubPropertiesFile))
 }
 def getVersionName = { ->
-    return "1.1.1.3"
+    return "1.1.1.4"
 }
 
 def getArtificatId = { ->

--- a/dConnectSDK/dConnectLibStreaming/libmedia/build.gradle
+++ b/dConnectSDK/dConnectLibStreaming/libmedia/build.gradle
@@ -6,7 +6,7 @@ if (githubPropertiesFile.exists()) {
     githubProperties.load(new FileInputStream(githubPropertiesFile))
 }
 def getVersionName = { ->
-    return "1.1.1.4"
+    return "1.1.1"
 }
 
 def getArtificatId = { ->
@@ -115,7 +115,7 @@ publishing {
             /** Configure path of your package repository on Github
              *  Replace GITHUB_USERID with your/organisation Github userID and REPOSITORY with the repository name on GitHub
              */
-            url = uri("https://maven.pkg.github.com/TakayukiHoshi1984/DeviceConnect-Android")
+            url = uri("https://maven.pkg.github.com/DeviceConnect/DeviceConnect-Android")
 
             credentials {
                 /**Create github.properties in root project folder file with gpr.usr=GITHUB_USER_ID  & gpr.key=PERSONAL_ACCESS_TOKEN**/

--- a/dConnectSDK/dConnectLibStreaming/libmedia/src/main/java/org/deviceconnect/android/libmedia/streaming/mjpeg/MJPEGEncoder.java
+++ b/dConnectSDK/dConnectLibStreaming/libmedia/src/main/java/org/deviceconnect/android/libmedia/streaming/mjpeg/MJPEGEncoder.java
@@ -1,5 +1,6 @@
 package org.deviceconnect.android.libmedia.streaming.mjpeg;
 
+
 public abstract class MJPEGEncoder {
     /**
      * MJPEG の設定を格納するクラス.
@@ -22,8 +23,9 @@ public abstract class MJPEGEncoder {
 
     /**
      * エンコードを開始します.
+     * @throws MJPEGEncoderException MJPEGのエンコードの開始に失敗した場合
      */
-    public abstract void start();
+    public abstract void start() throws MJPEGEncoderException;
 
     /**
      * エンコードを停止します.

--- a/dConnectSDK/dConnectLibStreaming/libmedia/src/main/java/org/deviceconnect/android/libmedia/streaming/mjpeg/MJPEGEncoderException.java
+++ b/dConnectSDK/dConnectLibStreaming/libmedia/src/main/java/org/deviceconnect/android/libmedia/streaming/mjpeg/MJPEGEncoderException.java
@@ -1,0 +1,18 @@
+package org.deviceconnect.android.libmedia.streaming.mjpeg;
+
+/**
+ * MJPEGEncoderの処理中に発生したエラーを扱う.
+ */
+public class MJPEGEncoderException extends RuntimeException {
+    public MJPEGEncoderException(String message) {
+        super(message);
+    }
+
+    public MJPEGEncoderException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public MJPEGEncoderException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/dConnectSDK/dConnectLibStreaming/libmedia/src/main/java/org/deviceconnect/android/libmedia/streaming/mjpeg/MJPEGServer.java
+++ b/dConnectSDK/dConnectLibStreaming/libmedia/src/main/java/org/deviceconnect/android/libmedia/streaming/mjpeg/MJPEGServer.java
@@ -208,7 +208,7 @@ public class MJPEGServer {
         }
     }
 
-    private synchronized void startMJPEGEncoder() {
+    private synchronized void startMJPEGEncoder() throws MJPEGEncoderException {
         if (mMJPEGEncoder != null) {
             return;
         }
@@ -218,6 +218,8 @@ public class MJPEGServer {
             mMJPEGEncoder.setCallback((byte[] jpeg) ->
                 mMixedReplaceMediaServer.offerMedia(jpeg));
             mMJPEGEncoder.start();
+        } else {
+            throw new MJPEGEncoderException("Failed to create MJPEG Encoder.");
         }
     }
 
@@ -262,7 +264,7 @@ public class MJPEGServer {
          *
          * @return MJPEG エンコーダ
          */
-        MJPEGEncoder createMJPEGEncoder();
+        MJPEGEncoder createMJPEGEncoder() throws MJPEGEncoderException;
 
         /**
          * MJPEG エンコーダの後始末を行います.

--- a/dConnectSDK/dConnectLibStreaming/libmedia/src/main/java/org/deviceconnect/android/libmedia/streaming/mjpeg/MJPEGServer.java
+++ b/dConnectSDK/dConnectLibStreaming/libmedia/src/main/java/org/deviceconnect/android/libmedia/streaming/mjpeg/MJPEGServer.java
@@ -208,7 +208,7 @@ public class MJPEGServer {
         }
     }
 
-    private synchronized void startMJPEGEncoder() throws MJPEGEncoderException {
+    private synchronized void startMJPEGEncoder() {
         if (mMJPEGEncoder != null) {
             return;
         }

--- a/dConnectSDK/dConnectLibStreaming/libmedia/src/main/java/org/deviceconnect/android/libmedia/streaming/mjpeg/MJPEGServer.java
+++ b/dConnectSDK/dConnectLibStreaming/libmedia/src/main/java/org/deviceconnect/android/libmedia/streaming/mjpeg/MJPEGServer.java
@@ -155,7 +155,12 @@ public class MJPEGServer {
                     if (mCallback != null) {
                         result = mCallback.onAccept(socket);
                         if (result) {
-                            startMJPEGEncoder();
+                            try {
+                                startMJPEGEncoder();
+                            } catch (Exception e) {
+                                stopMJPEGEncoder();
+                                return false;
+                            }
                         }
                     }
                     return result && mMJPEGEncoder != null;


### PR DESCRIPTION
## 修正内容
* libmediaのMJPEGEncoderのstartの中でエラーが発生した場合に後始末処理が行われない。
* ソースコードリファクタリング。